### PR TITLE
Rename "import manually" folder

### DIFF
--- a/src/content/docs/en/dev/folder-struct.md
+++ b/src/content/docs/en/dev/folder-struct.md
@@ -10,7 +10,7 @@ lastUpdated: 2024-02-18
 This page will help you know what to look into when you wanna hack up something
 
 # Repo structure
-- `Import manually`: Misc config files
+- `Extras`: Misc config files
 - `scriptdata`: Stores data for install script
 - `.config`: This is the main folder where normal config files are stored. (ags, hyprland, etc.)
 - `.local/bin`: Utility scripts. I might move them to ags folder later.

--- a/src/content/docs/en/i-i/01.setup.md
+++ b/src/content/docs/en/i-i/01.setup.md
@@ -73,8 +73,8 @@ You'll have to figure out the equivalents of packages inside `scriptdata/depende
 
 # Post installation
 ## Optional stuff
-### Import manually
-See if you're interested in anything in the `Import manually` folder.
+### Extra configs
+See if you're interested in anything in the `Extras` folder.
 ### Media integration with browser
 If you want media thumbnail from your browser to be shown, get the "Plasma browser integration" extension.
 - For [Chromium](https://chrome.google.com/webstore/detail/plasma-integration/cimiefiiaegbelhefglklhhakcgmhkai)

--- a/src/content/docs/vi/i-i/01.setup.md
+++ b/src/content/docs/vi/i-i/01.setup.md
@@ -54,7 +54,7 @@ Script này có thể chạy nhiều lần và có thể chọn chỉ thực hi�
   - Ấn `Super`+`/` để xem danh sách phím tắt
 
 - Không bắt buộc:
-   - Xem muốn gì thì lấy trong thư mục `Import manually`
+   - Xem muốn gì thì lấy trong thư mục `Extras`
    - Nếu muốn ảnh của nhạc/video ở trình duyệt thì lấy extension Plasma Browser Integration:
      - Cho [Chromium](https://chrome.google.com/webstore/detail/plasma-integration/cimiefiiaegbelhefglklhhakcgmhkai)
      - Cho [Firefox](https://addons.mozilla.org/en-US/firefox/addon/plasma-integration/)

--- a/src/content/docs/zh-cn/i-i/01.setup.md
+++ b/src/content/docs/zh-cn/i-i/01.setup.md
@@ -70,7 +70,7 @@ git clone https://github.com/end-4/dots-hyprland.git "$t" --filter=blob:none
 # 安装之后
 ## 自选项
 ### 手动导入
-看看在目录 `Import manually` 下是否有你感兴趣的。
+看看在目录 `Extras` 下是否有你感兴趣的。
 ### 浏览器的媒体集成
 若想显示来自浏览器的媒体缩略图，获取扩展程序 "Plasma browser integration"
 - 对于 [Chromium](https://chrome.google.com/webstore/detail/plasma-integration/cimiefiiaegbelhefglklhhakcgmhkai)


### PR DESCRIPTION
`import manually` was renamed in the actual dotfiles (https://github.com/end-4/dots-hyprland/commit/1e97c21e3dbae1fb43b241f9692ddb4cdd292df5),
but the docs weren't updated to reflect that change yet

I changed the folder name in english, vietnamese, and chinese. The chinese `01.setup.md` file has a header that reads "手动导入" ("import manually"), but that makes sense in context, so I didn't change it.