### PR TITLE
Expand Spanish wiki support with latest page content and localization updates

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -99,7 +99,21 @@ export default defineConfig({
         {
           label: 'illogical-impulse',
           collapsed: false,
-          badge: { text: 'New', variant: 'success' },
+          badge: {
+            text: {
+              'en': 'New',
+              // 'vi': '',
+              // 'zh-CN': '',
+              'es': 'Nuevo',
+              // 'ru': '',
+              // 'fr': '',
+              // 'pt-BR': '',
+              // 'de-DE': '',
+              // 'tr': '',
+              // 'zh-TW': '',
+            },
+            variant: 'success'
+          },
           autogenerate: { directory: 'ii-qs' },
         },
         {
@@ -142,7 +156,21 @@ export default defineConfig({
         },
         {
           label: 'Translate this wiki',
-          badge: { text: 'Help wanted', variant: 'note' },
+          badge: {
+            text: {
+              'en': 'Help wanted',
+              // 'vi': '',
+              // 'zh-CN': '',
+              'es': 'Ayúdanos',
+              // 'ru': '',
+              // 'fr': '',
+              // 'pt-BR': '',
+              // 'de-DE': '',
+              // 'tr': '',
+              // 'zh-TW': '',
+            },
+            variant: 'note'
+          },
           translations: {
             'zh-CN': '翻译此文档',
             'es': 'Traducir esta wiki',

--- a/package-lock.json
+++ b/package-lock.json
@@ -369,7 +369,6 @@
       "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.36.1.tgz",
       "integrity": "sha512-Fmt8mIsAIZN18Y4YQDI6p521GsYGe4hYxh9jWmz0pHBXnS5J7Na3TSXNya4eyIymCcKkuiKFbs7b/knsdGVYPg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/markdown-remark": "^6.3.1",
         "@astrojs/mdx": "^4.2.3",
@@ -2315,7 +2314,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2492,7 +2490,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.15.1.tgz",
       "integrity": "sha512-VM679M1qxOjGo6q3vKYDNDddkALGgMopG93IwbEXd3Buc2xVLuuPj4HNziNugSbPQx5S6UReMp5uzw10EJN81A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.7.4",
@@ -6106,7 +6103,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6750,7 +6746,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
       "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7343,7 +7338,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7720,7 +7714,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8333,7 +8326,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/content/docs/es/general/credits.mdx
+++ b/src/content/docs/es/general/credits.mdx
@@ -43,7 +43,7 @@ Este proyecto no hubiera alcanzado su estado actual sin las siguientes personas.
 
 **Por último, pero no menos importante:**
 - [Los generosos patrocinadores de end_4](https://github.com/sponsors/end-4) por su apoyo fundamental para el desarrollo a largo plazo.
-- [@outfoxxed](https://github.com/outfoxxed/) por su invaluable ayuda en la creación de la versión de Quickshell de los *dotfiles*.
+- [@outfoxxed](https://github.com/outfoxxed/) por su invaluable ayuda en la creación de la versión de Quickshell de los dotfiles.
 - Desarrolladores de todos los proyectos de código abierto que figuran como dependencias.
 - Bots de IA por proporcionar ejemplos útiles.
 - Todos los miembros de la comunidad que, con su amabilidad, participan en discusiones y brindan apoyo, fomentando un entorno acogedor.

--- a/src/content/docs/es/general/credits.mdx
+++ b/src/content/docs/es/general/credits.mdx
@@ -1,26 +1,59 @@
 ---
 title: Créditos
-lastUpdated: 2024-12-13
+lastUpdated: 2026-07-07
 ---
+
 ## Desarolladores
 - [end_4](https://github.com/end-4): El dueño y autor del repositorio.
-  - Creó las partes principales de este proyecto, como la configuración de Hyprland y AGS, y es quien las mantiene.
-    - Desde enero de 2023 hasta ahora.
-  - [clsty](https://github.com/clsty): El desarrollador asistente.
-    - Reescribió el script de instalación, creó este sitio de documentación y lo mantiene.
-    - Desde enero de 2024 hasta ahora.
+  - Desarrolló distintas variantes de *ricing* como parte principal de este proyecto.
+    - Ahora mantiene la última variante, siendo illogical-impulse en Quickshell.
+  - Tareas como gestionar incidencias, *PRs*, discusiones, actualizar o traducir este documento, etc.
+  - Otras tareas como crear el logotipo de illogical-impulse, etc.
+  - Desde enero de 2023 hasta ahora.
+- [clsty](https://github.com/clsty): El colaborador del repositorio.
+  - Desarrolló y mantiene los scripts de instalación en este sitio web.
+  - Tareas como gestionar incidencias, *PRs*, discusiones, actualizar o traducir este documento, etc.
+  - Otras tareas como plantillas de incidencias mediante *diagnose*, el flujo de trabajo *l10n-notify*, proporcionar el dominio `ii.clsty.link`, etc.
+  - Desde enero de 2024 hasta ahora.
 
-## Gracias
-- [@midn8hustlr](https://github.com/midn8hustlr): Diseñó e implementó el flujo de trabajo para los "workspace groups".
-- AGS: [Aylur's config](https://github.com/Aylur/dotfiles), [kotontrion's config](https://github.com/kotontrion/dotfiles)
-- EWW: [fufexan's config](https://github.com/fufexan/dotfiles) (El agradecé a más personas allí, btw)
-- Bots de IA por proporcionar ejemplos útiles
-- Contribuyentes de código abierto por su software y "ricers" por su inspiración (Sería una lista demasiado larga para poner aquí!)
+## Agradecimientos
 
-## Stonks
-- _Gracias!_
-[![Stargazers over time](https://starchart.cc/end-4/dots-hyprland.svg?background=%230d1117&axis=%23e6edf3&line=%234759e7)](https://starchart.cc/end-4/dots-hyprland)
+:::tip[Gracias]{icon="heart"}
+Este proyecto no hubiera alcanzado su estado actual sin las siguientes personas.
+:::
 
+**Los desarrolladores dedicados:** _Ver la sección anterior._
 
-## Inspiraciones
-- osu!lazer, Windows 11, Material Design 3, AvdanOS (concepto)
+**Los contribuidores apasionados:**
+- [@midn8hustlr](https://github.com/midn8hustlr) por mejorar significativamente el sistema de generación de color e implementar el flujo de trabajo de grupos de espacios de trabajo.
+- [@ZeyadMoustafaKamal](https://github.com/ZeyadMoustafaKamal) por introducir `uv` para crear entornos virtuales para Python.[^1]
+- [@xiaomeng2004](https://github.com/xiaomeng2004) por la implementación multilingüe en las versiones tanto AGS como Quickshell de illogical-impulse.
+- [@Makrennel](https://github.com/Makrennel) por introducir metapaquetes con PKGBUILDs locales para Arch Linux.
+- [@moetayuko](https://github.com/moetayuko) por muchos *PRs* que aplican correciones a las configuraciones AGS/Hyprland/Quickshell.
+- Soporte con múltiples distribuciones:
+  - Gentoo: aportado por [@jwihardi](https://github.com/jwihardi).
+  - Fedora: aportado por [@ririko6z](https://github.com/ririko6z).
+    - También [@EisregenHaha](https://github.com/EisregenHaha), quien mantuvo un *fork* para Fedora durante alrededor de 9 meses.
+- Y [muchas otras personas](https://github.com/end-4/dots-hyprland/graphs/contributors) (también [para el sitio de documentación](https://github.com/end-4/dots-hyprland-wiki/graphs/contributors)) cuyos nombres no aparecen en la lista anterior, pero que también dedicaron su tiempo a mejorar este proyecto.
+
+**Personas que compartieron sus configuraciones:**[^2]
+- Quickshell: [Soramane](https://github.com/caelestia-dots/shell/), [FridayFaerie](https://github.com/FridayFaerie/quickshell), [nydragon](https://github.com/nydragon/nysh).
+- AGS: [Aylur](https://github.com/Aylur/dotfiles/tree/ags-pre-ts), [kotontrion](https://github.com/kotontrion/dotfiles).
+- EWW: [fufexan](https://github.com/fufexan/dotfiles).
+
+**Por último, pero no menos importante:**
+- [Los generosos patrocinadores de end_4](https://github.com/sponsors/end-4) por su apoyo fundamental para el desarrollo a largo plazo.
+- [@outfoxxed](https://github.com/outfoxxed/) por su invaluable ayuda en la creación de la versión de Quickshell de los *dotfiles*.
+- Desarrolladores de todos los proyectos de código abierto que figuran como dependencias.
+- Bots de IA por proporcionar ejemplos útiles.
+- Todos los miembros de la comunidad que, con su amabilidad, participan en discusiones y brindan apoyo, fomentando un entorno acogedor.
+
+## Inspiraciones/Copias
+
+- Inspiración: osu!lazer, Windows 11, Material Design 3, AvdanOS (concepto).
+- Copia: La redistribución y recreación están permitidas siempre que se respete la licencia (GNU GPL v3.0).
+
+---
+
+[^1]: Gracias a [PR#1060](https://github.com/end-4/dots-hyprland/pull/1060) y al trabajo adicional de clsty, finalmente se logró rescatar el proyecto dots-hyprland de un estado casi crítico, ya que muchos usuarios no podían completar la instalación de dependencias debido a un fallo al instalar las dependencias de Python desde AUR.
+[^2]: Estas configuraciones proporcionan referencias útiles. Por cierto, también agradecieron a otras personas en sus repositorios.

--- a/src/content/docs/es/general/credits.mdx
+++ b/src/content/docs/es/general/credits.mdx
@@ -3,7 +3,7 @@ title: Créditos
 lastUpdated: 2026-07-07
 ---
 
-## Desarolladores
+## Desarrolladores
 - [end_4](https://github.com/end-4): El dueño y autor del repositorio.
   - Desarrolló distintas variantes de *ricing* como parte principal de este proyecto.
     - Ahora mantiene la última variante, siendo illogical-impulse en Quickshell.
@@ -29,7 +29,7 @@ Este proyecto no hubiera alcanzado su estado actual sin las siguientes personas.
 - [@ZeyadMoustafaKamal](https://github.com/ZeyadMoustafaKamal) por introducir `uv` para crear entornos virtuales para Python.[^1]
 - [@xiaomeng2004](https://github.com/xiaomeng2004) por la implementación multilingüe en las versiones tanto AGS como Quickshell de illogical-impulse.
 - [@Makrennel](https://github.com/Makrennel) por introducir metapaquetes con PKGBUILDs locales para Arch Linux.
-- [@moetayuko](https://github.com/moetayuko) por muchos *PRs* que aplican correciones a las configuraciones AGS/Hyprland/Quickshell.
+- [@moetayuko](https://github.com/moetayuko) por muchos *PRs* que aplican correcciones a las configuraciones AGS/Hyprland/Quickshell.
 - Soporte con múltiples distribuciones:
   - Gentoo: aportado por [@jwihardi](https://github.com/jwihardi).
   - Fedora: aportado por [@ririko6z](https://github.com/ririko6z).

--- a/src/content/docs/es/general/showcase.mdx
+++ b/src/content/docs/es/general/showcase.mdx
@@ -1,16 +1,34 @@
 ---
 title: Presentación
-lastUpdated: 2024-12-13
+lastUpdated: 2026-07-07
 ---
 
 <div align="center">
     <h1>Mantenido actualmente</h1>
 </div>
 
-## illogical_impulse
-[Inicio rápido](../../ii-ags/01setup)    •    [GitHub](https://github.com/end-4/dots-hyprland)
 
-![image](https://repository-images.githubusercontent.com/583820372/55988d08-a8db-421a-8761-f6e98ea89ce3)
+## illogical-impulse <sup>Quickshell</sup>
+![image](/screenshots/ii-qs.2.jpg)
+![image](/screenshots/ii-qs.3.jpg)
+![image](/screenshots/ii-qs.4.jpg)
+![image](/screenshots/ii-qs.5.jpg)
+
+---
+
+<div align="center">
+    <h1>No mantenido</h1>
+</div>
+
+:::caution
+La versión AGS de illogical impulse ya no recibe soporte.
+
+Aunque aún podría funcionar, tendrás que solucionar los problemas por tu cuenta.
+
+Una nueva incidencia de la versión AGS probablemente se cierre por no estar previsto.
+:::
+
+## illogical-impulse <sup>AGS</sup>
 ![image](/screenshots/ii-ags.2.png)
 ![image](/screenshots/ii-ags.3.png)
 ![image](/screenshots/ii-ags.4.png)
@@ -19,40 +37,37 @@ lastUpdated: 2024-12-13
 ---
 
 <div align="center">
-    <h1>No mantenido</h1>
+    <h1>No funcional</h1>
 </div>
 
 :::caution[Advertencia]
-Contenido siguiente:
-- Actualmente, NO funcionan (Ver [#99](https://github.com/end-4/dots-hyprland/issues/99)).
-- Las imágenes están aquí principalmente para tu placer visual.
-- Los archivos siguen disponibles, siéntete libre de tomarlos de [`archive`](https://github.com/end-4/dots-hyprland/tree/archive) crea una rama si estás dispuesto a ver espaguetis solucionar problemas.
+Información adicional:
+- Actualmente, NO funcionan (ver [#99](https://github.com/end-4/dots-hyprland/issues/99)).
+- Las imágenes están aquí principalmente para su disfrute visual.
+- Los archivos aún están disponibles, puedes obtenerlos de la rama [`archive`](https://github.com/end-4/dots-hyprland/tree/archive) si estás dispuesto a ver código spaguetti y solucionar problemas.
 :::
 
-:::tip[Tip]
+:::tip
 Haz click en la imagen para ver los videos de presentación.
 :::
 
 ## m3ww
-[GitHub](https://github.com/end-4/dots-hyprland/tree/archive)
 <a href="https://streamable.com/85ch8x">
  <img src="/screenshots/m3ww.1.png" alt="Material Eww!"/>
 </a>
 
 ## NovelKnock
-[GitHub](https://github.com/end-4/dots-hyprland/tree/archive)
 <a href="https://streamable.com/7vo61k">
- <img src="/screenshots/n-k.1.png" alt="Desktop Preview"/>
+ <img src="/screenshots/n-k.1.png" alt="Vista previa de escritorio"/>
 </a>
 
 ## Hybrid
-[GitHub](https://github.com/end-4/dots-hyprland/tree/archive)
 <a href="https://streamable.com/4oogot">
- <img src="/screenshots/hybrid.1.png" alt="click the circles!"/>
+ <img src="/screenshots/hybrid.1.png" alt="¡Haz click en los círculos!"/>
 </a>
 
 ## Windoes
-[GitHub](https://github.com/end-4/dots-hyprland/tree/archive)
 <a href="https://streamable.com/5qx614">
- <img src="/screenshots/windoes.1.png" alt="Desktop Preview"/>
+ <img src="/screenshots/windoes.1.png" alt="Vista previa de escritorio"/>
 </a>
+

--- a/src/content/docs/es/general/showcase.mdx
+++ b/src/content/docs/es/general/showcase.mdx
@@ -63,7 +63,7 @@ Haz click en la imagen para ver los videos de presentación.
 
 ## Hybrid
 <a href="https://streamable.com/4oogot">
- <img src="/screenshots/hybrid.1.png" alt="¡Haz click en los círculos!"/>
+ <img src="/screenshots/hybrid.1.png" alt="¡Haz clic en los círculos!"/>
 </a>
 
 ## Windoes

--- a/src/content/docs/es/ii-ags/00.description.mdx
+++ b/src/content/docs/es/ii-ags/00.description.mdx
@@ -2,7 +2,7 @@
 title: Introducción a illogical-impulse (versión basada en AGS)
 sidebar:
   label: Introducción
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 :::tip
@@ -18,9 +18,9 @@ Una nueva incidencia de la versión AGS probablemente se cierre por no estar pre
 :::
 
 # Qué esperar
-- Un entorno práctico y accesible diseñado para el uso diario
-- Una interfaz fácil de usar que no requiere que te adentres en complicaciones
-- Los atajos de teclado son similares a los de Windows
+- Un entorno práctico y accesible diseñado para el uso diario.
+- Una interfaz fácil de usar que no requiere que te adentres en complicaciones.
+- Los atajos de teclado son similares a los de Windows.
 
 ---
 

--- a/src/content/docs/es/ii-ags/00.description.mdx
+++ b/src/content/docs/es/ii-ags/00.description.mdx
@@ -1,9 +1,21 @@
 ---
-title: Introducción a illogical-impulse
+title: Introducción a illogical-impulse (versión basada en AGS)
 sidebar:
   label: Introducción
-lastUpdated: 2024-12-13
+lastUpdated: 2026-07-07
 ---
+
+:::tip
+Se recomienda cambiar a [la nueva versión de Quickshell](../../ii-qs/00description/), que tiene un rendimiento mucho mejor, a costa de perder algunas personalizaciones específicas y un mayor consumo de memoria.
+:::
+
+:::caution
+La versión AGS de illogical impulse ya no recibe soporte.
+
+Aunque aún podría funcionar, tendrás que solucionar los problemas por tu cuenta.
+
+Una nueva incidencia de la versión AGS probablemente se cierre por no estar previsto.
+:::
 
 # Qué esperar
 - Un entorno práctico y accesible diseñado para el uso diario

--- a/src/content/docs/es/ii-ags/01.setup.mdx
+++ b/src/content/docs/es/ii-ags/01.setup.mdx
@@ -1,63 +1,61 @@
 ---
 title: Instalar / Actualizar / Desinstalar
 layout: /src/layouts/autonum.astro
-lastUpdated: 2024-12-13
+lastUpdated: 2026-07-07
 ---
 
-# Instalando
+:::caution
+La versión AGS de illogical impulse ya no recibe soporte.
+
+Aunque aún podría funcionar, tendrás que solucionar los problemas por tu cuenta.
+
+Una nueva incidencia de la versión AGS probablemente se cierre por no estar previsto.
+:::
+
+# Instalación
 ## Antes de empezar
 
-- Esto solo provee **personalización a nivel de usuario**. Necesitas configurar la red de internet, bluetooth, GPU, etc. por tu propia cuenta.
-- EndeavourOS GNOME es recomendable para evitar problemas.
-  - Otras distribuciones basadas en Arch funcionarán muy bien.
-  - No estamos seguros en las no basadas en Arch.
+- Esto solo proporciona **personalización a nivel de usuario**. La instalación de GNOME probablemente te dará algunas funciones (básicas) del sistema, como red, Bluetooth, etc., pero se asume que ya las has configurado tú mismo.
+- EndeavourOS es recomendable para ahorrarte molestias.
+  - Otras distribuciones de Arch también funcionarán correctamente.
+  - ¿Usas una distribución no basada en Arch? Intenta encontrar la tuya en la página de [Discusiones](https://github.com/end-4/dots-hyprland/discussions).
   - ¡Nunca será necesario reinstalar tu sistema al usar Dotfiles!
-- Si solo tienes 8GiB de RAM, podrías querer [configurar zram](https://forum.endeavouros.com/t/enabling-zram-in-endeavouros/37746) (o swap), ya que compilar Hyprland consume bastantes recursos.
 
-## Instalación automática (para distribuciones basadas en Arch solamente)
-**El método recomendado**.
+## Instalación automática (solo para distribuciones Arch)
 
-Simplemente ejecuta este comando y sigue el procedimiento del script
-```bash
-bash <(curl -s "https://ii.clsty.link/setup.sh")
-```
-El comando anterior clona el repositorio en `~/.cache/dots-hyprland` por defecto. Puedes cambiar esta ruta especificándola como un argumento:
-```bash
-bash <(curl -s "https://ii.clsty.link/setup.sh") ~/Downloads/dots-hyprland
-```
-
-:::note[Método alternativo]
-O simplemente clona el repositorio y ejecuta el script de instalación:
+Clona el repositorio, cambia a la rama `ii-ags` y ejecuta el script de instalación:
 ```bash
 t=~/.cache/dots-hyprland   # No ensuciemos tu carpeta de inicio
 git clone https://github.com/end-4/dots-hyprland.git "$t" --filter=blob:none
+git -C "$t" checkout ii-ags
 "$t"/install.sh
 ```
-:::
 
-:::tip[Consejo]
+:::tip
 El script `install.sh` es idempotente e interactivo.
 Puedes ejecutarlo múltiples veces y elegir realizar solo ciertas acciones.
 :::
 
-## Para NixOS
+## Para NixOS (experimental)
 - Actualmente, estos dotfiles no se ofrecen (todavía) como un flake.
 - Aunque puedes revisar [el flake de NixOS de end_4](https://github.com/end-4/CirnOS)
   - Incluye configuración de home-manager. Querrás revisar la carpeta `homes`.
 
-## Para OpenSUSE
+- Ver también https://github.com/end-4/dots-hyprland/discussions/1093
+
+## Para OpenSUSE (experimental)
 - Ver https://github.com/end-4/dots-hyprland/discussions/485
 
-## Para Fedora
-- Ver https://github.com/EisregenHaha/fedora-hyprland
+## Para Fedora (experimental)
+- Ver [la rama F42-ags de EisregenHaha/fedora-hyprland](https://github.com/EisregenHaha/fedora-hyprland/tree/F42-ags)
 
-- ver también (discusión anterior): https://github.com/end-4/dots-hyprland/discussions/840
+- Ver también (discusión anterior): https://github.com/end-4/dots-hyprland/discussions/840
 
-## Instalación manual (básicamente cualquier distro)
-:::note[Nota para distribuciones no-Arch]
-Tendrás que averiguar los equivalentes de los paquetes del valor del array `depends` dentro de esos `scriptdata/arch-packages/*/PKGBUILD` más tarde cuando instales las dependencias.
+## Instalación manual (básicamente cualquier distribución)
+:::note[Nota para distribuciones no basadas en Arch]
+Más adelante, cuando instales las dependencias, tendrás que averiguar los equivalentes de los paquetes del valor del arreglo `depends` dentro de esos `scriptdata/arch-packages/*/PKGBUILD`.
 - Para obtener información de un paquete (por ejemplo, qué ejecutable(s) proporciona), búscalo en [Arch Linux Packages](https://archlinux.org/packages) o en el [AUR](https://aur.archlinux.org/packages).
-- Si has terminado con éxito la instalación en alguna distribución Linux no basada en Arch, eres muy bienvenido a compartir la lista de paquetes (también otros pasos si es necesario) en [Discussions](https://github.com/end-4/dots-hyprland/discussions), y podríamos automatizar la instalación para ella en el futuro. ¡Gracias!
+- Si has terminado con éxito la instalación en alguna distribución Linux no basada en Arch, eres muy bienvenido a compartir la lista de paquetes (también otros pasos si es necesario) en [Discusiones](https://github.com/end-4/dots-hyprland/discussions), y podríamos automatizar la instalación para ella en el futuro. ¡Gracias!
 :::
 
 - Clona y ve al directorio
@@ -66,7 +64,7 @@ Tendrás que averiguar los equivalentes de los paquetes del valor del array `dep
   git clone https://github.com/end-4/dots-hyprland.git "$t" --filter=blob:none
   cd "$t"
   ```
-- Obtener paquetes: Instala todos los paquetes listados como el valor del array `depends` dentro de esos `scriptdata/arch-packages/*/PKGBUILD`. Para Arch Linux, solo usa un ayudante de AUR como `yay`.
+- Obtener paquetes: Instala todos los paquetes listados como el valor del arreglo `depends` dentro de esos `scriptdata/arch-packages/*/PKGBUILD`. Para Arch Linux, solo usa un ayudante de AUR como `yay`.
 
 - Ejecuta `manual-install-helper.sh` para instalar el resto de las dependencias.
   - También puedes instalar alternativas adecuadas como hayas descubierto, pero asegúrate de `git checkout` al commit requerido al instalar AGS.
@@ -80,12 +78,21 @@ Tendrás que averiguar los equivalentes de los paquetes del valor del array `dep
   - `Ctrl`+`Super`+`T` para seleccionar un fondo de pantalla
   - `Super`+`/` para una lista de atajos de teclado. ¡Diviértete!
 
-# Post instalación
+# Después de la instalación
+## Cosas no tan opcionales
+### Temas de Qt
+- Selecciona KVantum en las ventanas emergentes al ejecutar:
+```sh
+kcmshell6 kcm_style
+kcmshell6 kcm_colors
+```
+### Evitar conflictos con daemons de notificación
+- Los daemons de notificación como `dunst` y `mako` pueden venir con las personalizaciones de tu distribución y pueden interferir con AGS si se inician primero. Se recomienda desinstalarlos si no los usas en otro lugar.
 ## Cosas opcionales
-### Configuraciones extra
+### Configuraciones adicionales
 Revisa si te interesa algo en la carpeta `Extras`.
 ### Integración de medios con el navegador
-Si quieres que la miniatura de medios de tu navegador se muestre, obtén la extensión "Integración de navegador de Plasma".
+Si quieres que la miniatura de medios de tu navegador se muestre, obtén la extensión "Plasma Integration".
 - Para [Chromium](https://chrome.google.com/webstore/detail/plasma-integration/cimiefiiaegbelhefglklhhakcgmhkai)
 - Para [Firefox](https://addons.mozilla.org/en-US/firefox/addon/plasma-integration/)
 
@@ -95,13 +102,13 @@ Pon esta línea en tu `~/.zshrc` para soportar el esquema de colores para ZSH:
 source ~/.config/zshrc.d/dots-hyprland.zsh
 ```
 
-## Lanzando Hyprland
-Para lanzar Hyprland, puedes usar un DM (Display Manager) o simplemente `tty`.
+## Iniciando Hyprland
+- Para iniciar Hyprland, puedes usar un gestor de pantalla (DM) o simplemente `tty`.
+- La wiki de Hyprland recomienda iniciar Hyprland con la sesión gestionada por uswm, pero yo no lo recomiendo. Usar esta opción no daña los dotfiles, pero ten en cuenta que podrías recibir mensajes no deseados de otros entornos de escritorio (por ejemplo, diálogos de autenticación duplicados).
 
-Consulta [Hyprland wiki](https://wiki.hyprland.org/Getting-Started/Master-Tutorial/#launching-hyprland) para más detalles.
+Ver [wiki de Hyprland](https://wiki.hyprland.org/Getting-Started/Master-Tutorial/#launching-hyprland) para obtener más detalles. A continuación, encontrarás algunos consejos adicionales.
 
-Aquí hay algunos consejos adicionales.
-### ¿Cómo auto-lanzar Hyprland después de iniciar sesión en `tty1`?
+### ¿Cómo auto-iniciar Hyprland después de iniciar sesión en `tty1`?
 Para ZSH o BASH, agrega esta línea al **final** de tu `~/.zshrc` o `~/.bashrc`:
 ```bash
 source ~/.config/zshrc.d/auto-Hypr.sh
@@ -112,7 +119,7 @@ Para FISH, agrega esta línea al **final** de tu `~/.config/fish/config.fish`:
 source ~/.config/fish/auto-Hypr.fish
 ```
 
-P.D. Se recomienda deshabilitar el DM si deseas lanzar Hyprland a través de tty.
+P.D. Se recomienda deshabilitar el DM si deseas iniciar Hyprland a través de tty.
 
 ### Soy un novato. ¿Qué es un tty y DM?
 
@@ -121,8 +128,8 @@ Aquí hay una breve introducción para darte un acceso rápido, aunque no exacta
 Puedes ver `tty` como una especie de "base" de un sistema Linux.
 Normalmente hay 7 `tty`s: `tty1` a `tty7`. Puedes presionar `Ctrl+Alt+F<n>` para cambiar a `tty<n>`, y escribir tu nombre de usuario y contraseña para iniciar sesión.
 
-Después de iniciar sesión, puedes lanzar un entorno gráfico a través de un comando, por ejemplo, `Hyprland`.
-De hecho, la mayoría de las interfaces gráficas solo se pueden lanzar **después** de iniciar sesión.
+Después de iniciar sesión, puedes iniciar un entorno gráfico a través de un comando, por ejemplo, `Hyprland`.
+De hecho, la mayoría de las interfaces gráficas solo se pueden iniciar **después** de iniciar sesión.
 
 Pero, ¿qué pasa si queremos una interfaz gráfica para la propia interfaz de inicio de sesión?
 
@@ -130,7 +137,7 @@ Entonces, aquí viene el DM (Display Manager, también llamado "LM", es decir, L
 - Algunos DM comúnmente usados:
   - `sddm`: A menudo usado con KDE Plasma.
   - `gdm`: A menudo usado con Gnome.
-- Está habilitado a nivel del sistema y se lanza automáticamente después de arrancar el sistema (aún no iniciar sesión).
+- Está habilitado a nivel del sistema y se inicia automáticamente después de arrancar el sistema (aún no iniciar sesión).
   - En una distro basada en systemd, el DM generalmente está habilitado como un servicio systemd. Ejecuta lo siguiente para ver qué DM está habilitado.
    ```bash
    grep 'ExecStart=' /etc/systemd/system/display-manager.service
@@ -141,7 +148,7 @@ Entonces, aquí viene el DM (Display Manager, también llamado "LM", es decir, L
    - Normalmente, busca en la ruta `/usr/share/xsessions` para los de X11, y `/usr/share/wayland-sessions` para los de Wayland.
    - Los archivos de escritorio bajo estos directorios contienen la información de los entornos gráficos.
 
-# Actualizando
+# Actualización
 ## Instalado automáticamente
 - `cd` al directorio del repositorio
 - Ejecuta `git pull` para obtener los últimos cambios.
@@ -156,7 +163,7 @@ Ejecuta `./install.sh -h` para ver más uso.
 - Toma los archivos que desees. Normalmente querrás tomar la carpeta `.config/ags`.
 - Ejecuta `manual-install-helper.sh` para actualizar algunas de las dependencias.
 
-# Desinstalando
+# Desinstalación
 - Se recomienda **fuertemente** la desinstalación manual
 - Actualmente, hay un script para desinstalación, pero está lejos de ser perfecto y no se mantiene activamente.
 - Aquí va una larga explicación si te importa:
@@ -172,3 +179,11 @@ Ejecuta `./install.sh -h` para ver más uso.
 > 
 > En conclusión, es casi imposible escribir un script de desinstalación adecuado.
 > Es mejor que hagas los cambios revertidos manualmente según lo necesites.
+
+:::note[Estado actual]
+Dado que ahora usamos PKGBUILD locales para distribuciones basadas en Arch,
+el script `uninstall.sh` puede desinstalar correctamente los paquetes de Arch/AUR,
+pero la eliminación de archivos de configuración aún no es perfecta.
+
+Ver también https://github.com/end-4/dots-hyprland/issues/838#issuecomment-2406220007
+:::

--- a/src/content/docs/es/ii-ags/01.setup.mdx
+++ b/src/content/docs/es/ii-ags/01.setup.mdx
@@ -41,19 +41,19 @@ Puedes ejecutarlo múltiples veces y elegir realizar solo ciertas acciones.
 - Aunque puedes revisar [el flake de NixOS de end_4](https://github.com/end-4/CirnOS)
   - Incluye configuración de home-manager. Querrás revisar la carpeta `homes`.
 
-- Ver también https://github.com/end-4/dots-hyprland/discussions/1093
+- Consulta también https://github.com/end-4/dots-hyprland/discussions/1093
 
 ## Para OpenSUSE (experimental)
-- Ver https://github.com/end-4/dots-hyprland/discussions/485
+- Consulta https://github.com/end-4/dots-hyprland/discussions/485
 
 ## Para Fedora (experimental)
-- Ver [la rama F42-ags de EisregenHaha/fedora-hyprland](https://github.com/EisregenHaha/fedora-hyprland/tree/F42-ags)
+- Consulta [la rama F42-ags de EisregenHaha/fedora-hyprland](https://github.com/EisregenHaha/fedora-hyprland/tree/F42-ags)
 
-- Ver también (discusión anterior): https://github.com/end-4/dots-hyprland/discussions/840
+- Consulta también (discusión anterior): https://github.com/end-4/dots-hyprland/discussions/840
 
 ## Instalación manual (básicamente cualquier distribución)
 :::note[Nota para distribuciones no basadas en Arch]
-Más adelante, cuando instales las dependencias, tendrás que averiguar los equivalentes de los paquetes del valor del arreglo `depends` dentro de esos `scriptdata/arch-packages/*/PKGBUILD`.
+Más adelante, cuando instales las dependencias, tendrás que averiguar los equivalentes de los paquetes del valor del arreglo `depends` dentro de `scriptdata/arch-packages/*/PKGBUILD`.
 - Para obtener información de un paquete (por ejemplo, qué ejecutable(s) proporciona), búscalo en [Arch Linux Packages](https://archlinux.org/packages) o en el [AUR](https://aur.archlinux.org/packages).
 - Si has terminado con éxito la instalación en alguna distribución Linux no basada en Arch, eres muy bienvenido a compartir la lista de paquetes (también otros pasos si es necesario) en [Discusiones](https://github.com/end-4/dots-hyprland/discussions), y podríamos automatizar la instalación para ella en el futuro. ¡Gracias!
 :::
@@ -64,7 +64,7 @@ Más adelante, cuando instales las dependencias, tendrás que averiguar los equi
   git clone https://github.com/end-4/dots-hyprland.git "$t" --filter=blob:none
   cd "$t"
   ```
-- Obtener paquetes: Instala todos los paquetes listados como el valor del arreglo `depends` dentro de esos `scriptdata/arch-packages/*/PKGBUILD`. Para Arch Linux, solo usa un ayudante de AUR como `yay`.
+- Obtener paquetes: Instala todos los paquetes listados como el valor del arreglo `depends` dentro de `scriptdata/arch-packages/*/PKGBUILD`. Para Arch Linux, solo usa un ayudante de AUR como `yay`.
 
 - Ejecuta `manual-install-helper.sh` para instalar el resto de las dependencias.
   - También puedes instalar alternativas adecuadas como hayas descubierto, pero asegúrate de `git checkout` al commit requerido al instalar AGS.
@@ -79,7 +79,7 @@ Más adelante, cuando instales las dependencias, tendrás que averiguar los equi
   - `Super`+`/` para una lista de atajos de teclado. ¡Diviértete!
 
 # Después de la instalación
-## Cosas no tan opcionales
+## Detalles no tan opcionales
 ### Temas de Qt
 - Selecciona KVantum en las ventanas emergentes al ejecutar:
 ```sh
@@ -88,7 +88,7 @@ kcmshell6 kcm_colors
 ```
 ### Evitar conflictos con daemons de notificación
 - Los daemons de notificación como `dunst` y `mako` pueden venir con las personalizaciones de tu distribución y pueden interferir con AGS si se inician primero. Se recomienda desinstalarlos si no los usas en otro lugar.
-## Cosas opcionales
+## Detalles opcionales
 ### Configuraciones adicionales
 Revisa si te interesa algo en la carpeta `Extras`.
 ### Integración de medios con el navegador
@@ -106,7 +106,7 @@ source ~/.config/zshrc.d/dots-hyprland.zsh
 - Para iniciar Hyprland, puedes usar un gestor de pantalla (DM) o simplemente `tty`.
 - La wiki de Hyprland recomienda iniciar Hyprland con la sesión gestionada por uswm, pero yo no lo recomiendo. Usar esta opción no daña los dotfiles, pero ten en cuenta que podrías recibir mensajes no deseados de otros entornos de escritorio (por ejemplo, diálogos de autenticación duplicados).
 
-Ver [wiki de Hyprland](https://wiki.hyprland.org/Getting-Started/Master-Tutorial/#launching-hyprland) para obtener más detalles. A continuación, encontrarás algunos consejos adicionales.
+Consulta la [wiki de Hyprland](https://wiki.hyprland.org/Getting-Started/Master-Tutorial/#launching-hyprland) para obtener más detalles. A continuación, encontrarás algunos consejos adicionales.
 
 ### ¿Cómo auto-iniciar Hyprland después de iniciar sesión en `tty1`?
 Para ZSH o BASH, agrega esta línea al **final** de tu `~/.zshrc` o `~/.bashrc`:
@@ -139,10 +139,10 @@ Entonces, aquí viene el DM (Display Manager, también llamado "LM", es decir, L
   - `gdm`: A menudo usado con Gnome.
 - Está habilitado a nivel del sistema y se inicia automáticamente después de arrancar el sistema (aún no iniciar sesión).
   - En una distro basada en systemd, el DM generalmente está habilitado como un servicio systemd. Ejecuta lo siguiente para ver qué DM está habilitado.
-   ```bash
-   grep 'ExecStart=' /etc/systemd/system/display-manager.service
-   ```
-   Si devuelve "No such file or directory", entonces no hay DM habilitado, o esta no es una distro basada en systemd.
+    ```bash
+    grep 'ExecStart=' /etc/systemd/system/display-manager.service
+    ```
+    Si devuelve "No such file or directory", entonces no hay DM habilitado, o esta no es una distro basada en systemd.
 - Te proporciona una interfaz gráfica para iniciar sesión y elegir el entorno gráfico (por ejemplo, Hyprland).
   - ¿Cómo sabe el DM qué entornos gráficos están disponibles?
    - Normalmente, busca en la ruta `/usr/share/xsessions` para los de X11, y `/usr/share/wayland-sessions` para los de Wayland.
@@ -185,5 +185,5 @@ Dado que ahora usamos PKGBUILD locales para distribuciones basadas en Arch,
 el script `uninstall.sh` puede desinstalar correctamente los paquetes de Arch/AUR,
 pero la eliminación de archivos de configuración aún no es perfecta.
 
-Ver también https://github.com/end-4/dots-hyprland/issues/838#issuecomment-2406220007
+Consulta también https://github.com/end-4/dots-hyprland/issues/838#issuecomment-2406220007
 :::

--- a/src/content/docs/es/ii-ags/01.setup.mdx
+++ b/src/content/docs/es/ii-ags/01.setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Instalar / Actualizar / Desinstalar
 layout: /src/layouts/autonum.astro
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 :::caution
@@ -137,12 +137,12 @@ Entonces, aquí viene el DM (Display Manager, también llamado "LM", es decir, L
 - Algunos DM comúnmente usados:
   - `sddm`: A menudo usado con KDE Plasma.
   - `gdm`: A menudo usado con Gnome.
-- Está habilitado a nivel del sistema y se inicia automáticamente después de arrancar el sistema (aún no iniciar sesión).
+- Está habilitado a nivel del sistema y se inicia automáticamente después de arrancar el sistema (aún sin iniciar sesión).
   - En una distro basada en systemd, el DM generalmente está habilitado como un servicio systemd. Ejecuta lo siguiente para ver qué DM está habilitado.
     ```bash
     grep 'ExecStart=' /etc/systemd/system/display-manager.service
     ```
-    Si devuelve "No such file or directory", entonces no hay DM habilitado, o esta no es una distro basada en systemd.
+    Si devuelve "No such file or directory", entonces no hay DM habilitado, o esta no es una distribución basada en systemd.
 - Te proporciona una interfaz gráfica para iniciar sesión y elegir el entorno gráfico (por ejemplo, Hyprland).
   - ¿Cómo sabe el DM qué entornos gráficos están disponibles?
    - Normalmente, busca en la ruta `/usr/share/xsessions` para los de X11, y `/usr/share/wayland-sessions` para los de Wayland.
@@ -164,7 +164,7 @@ Ejecuta `./install.sh -h` para ver más uso.
 - Ejecuta `manual-install-helper.sh` para actualizar algunas de las dependencias.
 
 # Desinstalación
-- Se recomienda **fuertemente** la desinstalación manual
+- Se recomienda **fuertemente** la desinstalación manual.
 - Actualmente, hay un script para desinstalación, pero está lejos de ser perfecto y no se mantiene activamente.
 - Aquí va una larga explicación si te importa:
 

--- a/src/content/docs/es/ii-ags/02.usage.mdx
+++ b/src/content/docs/es/ii-ags/02.usage.mdx
@@ -1,7 +1,7 @@
 ---
 title: Uso
 layout: /src/layouts/autonum.astro
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 :::caution
@@ -21,54 +21,54 @@ También incluye algunas Acciones para el lanzador.
 Presiona `Super` o `Super`+`Tab` para abrir.
 
 - **Ventanas**
-  - Arrastra para moverlas a diferentes espacios de trabajo
-  - Haz clic derecho para algunas opciones
+  - Arrastra para moverlas a diferentes espacios de trabajo.
+  - Haz clic derecho para algunas opciones.
 - **Buscar**
-  - <u>Cálculo</u>: Escribe algo que comience con un número
+  - <u>Cálculo</u>: Escribe algo que comience con un número.
   - <u>Comandos</u>: Serán detectados y mostrados si los escribes.
-    - Ejecuta sin interfaz por defecto
+    - Ejecuta sin interfaz por defecto.
     - Si el comando comienza con sudo, se lanzará en la terminal `foot`.
   - <u>Búsqueda de directorios</u>: Escribe un directorio comenzando con `~` o `/`.
-    - Se mostrarán subdirectorios si la ruta es correcta. Activar abre carpeta/archivo
-    - Presiona enter directamente en la entrada para abrir la carpeta/archivo escrito
-  - <u>Acciones</u>: Cada acción comienza con un `>`. Consulta la **hoja de trucos de atajos de teclado** para una lista
+    - Se mostrarán subdirectorios si la ruta es correcta. Activar abre carpeta/archivo.
+    - Presiona enter directamente en la entrada para abrir la carpeta/archivo escrito.
+  - <u>Acciones</u>: Cada acción comienza con un `>`. Consulta la **hoja de trucos de atajos de teclado** para una lista.
   - <u>Aplicaciones</u> por defecto, ¡por supuesto!
 
 ## Controles de la barra principal
 - Medios:
   - Esquina superior derecha
-    - Clic medio: reproducir/pausar medios
-    - Clic derecho: siguiente pista
-    - Desplazar: cambiar volumen
-  - Haz clic en la pastilla de música para una ventana de controles
-- Brillo: Desplazar en la esquina superior izquierda
-- Lanzador/Overview: Haz clic derecho en el widget de espacio de trabajo
-- Teclado virtual: Clic medio en el widget de espacio de trabajo
-- Copiar texto en notificación: Haz clic y mantén presionado durante unos 800ms (referencia: [#224](https://github.com/end-4/dots-hyprland/issues/224#issuecomment-1923706599))
+    - Clic medio: reproducir/pausar medios.
+    - Clic derecho: siguiente pista.
+    - Desplazar: cambiar volumen.
+  - Haz clic en la pastilla de música para una ventana de controles.
+- Brillo: Desplazar en la esquina superior izquierda.
+- Lanzador/Overview: Haz clic derecho en el widget de espacio de trabajo.
+- Teclado virtual: Clic medio en el widget de espacio de trabajo.
+- Copiar texto en notificación: Haz clic y mantén presionado durante unos 800ms (referencia: [#224](https://github.com/end-4/dots-hyprland/issues/224#issuecomment-1923706599)).
 - Espacios de trabajo:
-  - Desplazar para cambiar espacios de trabajo
-  - Haz clic en un espacio de trabajo para enfocar
-  - Haz clic en el botón lateral (en ratones para juegos) para alternar espacio de trabajo especial (scratchpad)
+  - Desplazar para cambiar espacios de trabajo.
+  - Haz clic en un espacio de trabajo para enfocar/
+  - Haz clic en el botón lateral (en ratones para juegos) para alternar espacio de trabajo especial (scratchpad).
 
 # APIs
 
 _Disponibles en la barra lateral izquierda_
 
 ## Servicios de IA
-- Cada servicio de IA requiere una clave API
-  - Si no tienes una, habrá un aviso que te llevará al sitio web del proveedor cuando hagas clic
-  - Una vez que hayas seguido las instrucciones en ese sitio web y obtengas una clave, simplemente pégala y envíala en el cuadro de chat de la barra lateral y se guardará. El aviso anterior debería desaparecer y deberías poder usar la API
+- Cada servicio de IA requiere una clave API.
+  - Si no tienes una, habrá un aviso que te llevará al sitio web del proveedor cuando hagas clic.
+  - Una vez que hayas seguido las instrucciones en ese sitio web y obtengas una clave, simplemente pégala y envíala en el cuadro de chat de la barra lateral y se guardará. El aviso anterior debería desaparecer y deberías poder usar la API.
   - En caso de que necesites cambiar la clave, usa el comando `/key`. Te dirá qué hacer.
 
 ## Servicios Waifu
 - No se requiere clave API, ¡yay!
-- Para la pestaña "Waifus", ingresa una categoría. Consulta su documentación para una lista: https://waifu.pics/docs
+- Para la pestaña "Waifus", ingresa una categoría. Consulta su documentación para una lista: https://waifu.pics/docs.
 - Para la pestaña "Anime Booru":
-  - `/yandere` para cambiar al modo yande.re (para imágenes generales) [Por defecto]
-  - `/konachan` para cambiar a Konachan (para fondos de pantalla)
-  - Ingresa etiquetas separadas por espacios y obtendrás 20 imágenes (por defecto, configurable)
-  - Incluye un número para ir a esa página
-  - <sub><sub><sub>¿Por qué no usar simplemente la interfaz web, preguntas? los filtros están deshabilitados por defecto en la API</sub></sub></sub>
+  - `/yandere` para cambiar al modo yande.re (para imágenes generales) [Por defecto].
+  - `/konachan` para cambiar a Konachan (para fondos de pantalla).
+  - Ingresa etiquetas separadas por espacios y obtendrás 20 imágenes (por defecto, configurable).
+  - Incluye un número para ir a esa página.
+  - <sub><sub><sub>¿Por qué no usar simplemente la interfaz web, preguntas? Los filtros están deshabilitados por defecto en la API.</sub></sub></sub>
 
 # Fondo de pantalla y colores
 - Para elegir un fondo de pantalla, pulsa `Ctrl` + `Super` + `T` y selecciona una imagen. Los widgets, aplicaciones GTK (tras reiniciarlas) y aplicaciones Qt (consulta [cómo configurarlo correctamente](https://ii.clsty.link/en/ii-ags/01setup/#not-so-optional-stuff)) tendrán el tema de colores Material Design.
@@ -87,13 +87,13 @@ La Agrupación de Espacios de Trabajo introduce un sistema flexible que permite 
 - **Características Clave**
   - **Espacios de Trabajo Escalables**: Supera el límite de 10 espacios de trabajo sin desordenar la barra de espacios de trabajo o el widget de overview. Crea tantos espacios de trabajo como necesites sin comprometer la organización.
   - **Grupos de Espacios de Trabajo**: Los espacios de trabajo se dividen automáticamente en grupos de 10 (por ejemplo, 1-10, 11-20, 21-30). El espacio de trabajo activo determina el grupo visible en la barra (así como el widget de overview).
-  - **Soporte de Atajos de Teclado**: Los atajos de teclado de Hyprland están configurados para adaptarse sin problemas a esta función
-    - Presionar `Super` + `3` te mueve al espacio de trabajo 3 si tu espacio de trabajo actual es 1-10, o al espacio de trabajo 13 si tu espacio de trabajo actual es 11-20
+  - **Soporte de Atajos de Teclado**: Los atajos de teclado de Hyprland están configurados para adaptarse sin problemas a esta función.
+    - Presionar `Super` + `3` te mueve al espacio de trabajo 3 si tu espacio de trabajo actual es 1-10, o al espacio de trabajo 13 si tu espacio de trabajo actual es 11-20.
 
 - **Beneficios**
-  - **Dominio Multitarea**: Cambia sin esfuerzo entre diferentes tareas o proyectos dedicando grupos de espacios de trabajo a contextos específicos
-  - **Entorno Despejado**: Mantén una experiencia de escritorio limpia y organizada, incluso con un alto número de espacios de trabajo
-  - **Poder Multi-Monitor**: Crea grupos de espacios de trabajo específicos para cada monitor para un flujo de trabajo inspirado en [awesome-wm](https://awesomewm.org/)
+  - **Dominio Multitarea**: Cambia sin esfuerzo entre diferentes tareas o proyectos dedicando grupos de espacios de trabajo a contextos específicos.
+  - **Entorno Despejado**: Mantén una experiencia de escritorio limpia y organizada, incluso con un alto número de espacios de trabajo.
+  - **Poder Multi-Monitor**: Crea grupos de espacios de trabajo específicos para cada monitor para un flujo de trabajo inspirado en [awesome-wm](https://awesomewm.org/).
     - Por ejemplo, 1-10 en monitor-1, 11-20 en monitor-2, 21-30 en monitores-3, y así sucesivamente.
 
 ## Navegación y Gestión de Espacios de Trabajo
@@ -142,7 +142,7 @@ Los grupos de espacios de trabajo no son compatibles de forma nativa en Hyprland
 :::
 
 # Modo de Enfoque
-- Para alternar, presiona `Ctrl` + `Alt` + `/`
-- El ancho de la barra se reducirá a la mitad
-- Solo se mostrará el indicador de espacio de trabajo sin números
-- Se vuelve rojo cuando la batería está baja
+- Para alternar, presiona `Ctrl` + `Alt` + `/`.
+- El ancho de la barra se reducirá a la mitad.
+- Solo se mostrará el indicador de espacio de trabajo sin números.
+- Se vuelve rojo cuando la batería está baja.

--- a/src/content/docs/es/ii-ags/02.usage.mdx
+++ b/src/content/docs/es/ii-ags/02.usage.mdx
@@ -47,7 +47,7 @@ Presiona `Super` o `Super`+`Tab` para abrir.
 - Copiar texto en notificación: Haz clic y mantén presionado durante unos 800ms (referencia: [#224](https://github.com/end-4/dots-hyprland/issues/224#issuecomment-1923706599)).
 - Espacios de trabajo:
   - Desplazar para cambiar espacios de trabajo.
-  - Haz clic en un espacio de trabajo para enfocar/
+  - Haz clic en un espacio de trabajo para enfocar.
   - Haz clic en el botón lateral (en ratones para juegos) para alternar espacio de trabajo especial (scratchpad).
 
 # APIs

--- a/src/content/docs/es/ii-ags/02.usage.mdx
+++ b/src/content/docs/es/ii-ags/02.usage.mdx
@@ -1,15 +1,23 @@
 ---
 title: Uso
 layout: /src/layouts/autonum.astro
-lastUpdated: 2024-12-13
+lastUpdated: 2026-07-07
 ---
+
+:::caution
+La versión AGS de illogical impulse ya no recibe soporte.
+
+Aunque aún podría funcionar, tendrás que solucionar los problemas por tu cuenta.
+
+Una nueva incidencia de la versión AGS probablemente se cierre por no estar previsto.
+:::
 
 # General
 Primero, para una lista de atajos de teclado, presiona `Super`+`/`.
 
 También incluye algunas Acciones para el lanzador.
 
-## Overview/lanzador
+## Resumen/lanzador
 Presiona `Super` o `Super`+`Tab` para abrir.
 
 - **Ventanas**
@@ -61,6 +69,12 @@ _Disponibles en la barra lateral izquierda_
   - Ingresa etiquetas separadas por espacios y obtendrás 20 imágenes (por defecto, configurable)
   - Incluye un número para ir a esa página
   - <sub><sub><sub>¿Por qué no usar simplemente la interfaz web, preguntas? los filtros están deshabilitados por defecto en la API</sub></sub></sub>
+
+# Fondo de pantalla y colores
+- Para elegir un fondo de pantalla, pulsa `Ctrl` + `Super` + `T` y selecciona una imagen. Los widgets, aplicaciones GTK (tras reiniciarlas) y aplicaciones Qt (consulta [cómo configurarlo correctamente](https://ii.clsty.link/en/ii-ags/01setup/#not-so-optional-stuff)) tendrán el tema de colores Material Design.
+- Si prefieres colores más vibrantes o apagados, puedes cambiar la paleta de colores Material Design.
+  - Pulsa `Super` + `,` para abrir el panel de la paleta de colores. Haz clic en la flecha pequeña de la esquina inferior derecha para ver las opciones.
+  - Elige la paleta que desees, como Tonal Spot (la normal), Neutra (colores más apagados) o Vibrante...
 
 # Grupos de Espacios de Trabajo
 

--- a/src/content/docs/es/ii-ags/02.usage.mdx
+++ b/src/content/docs/es/ii-ags/02.usage.mdx
@@ -65,7 +65,7 @@ _Disponibles en la barra lateral izquierda_
 - Para la pestaña "Waifus", ingresa una categoría. Consulta su documentación para una lista: https://waifu.pics/docs.
 - Para la pestaña "Anime Booru":
   - `/mode yandere` para cambiar al modo yande.re (para imágenes generales) [Por defecto].
-  - `/konachan` para cambiar a Konachan (para fondos de pantalla).
+  - `/mode konachan` para cambiar a Konachan (para fondos de pantalla).
   - Ingresa etiquetas separadas por espacios y obtendrás 20 imágenes (por defecto, configurable).
   - Incluye un número para ir a esa página.
   - <sub><sub><sub>¿Por qué no usar simplemente la interfaz web, preguntas? Los filtros están deshabilitados por defecto en la API.</sub></sub></sub>

--- a/src/content/docs/es/ii-ags/02.usage.mdx
+++ b/src/content/docs/es/ii-ags/02.usage.mdx
@@ -64,7 +64,7 @@ _Disponibles en la barra lateral izquierda_
 - No se requiere clave API, ¡yay!
 - Para la pestaña "Waifus", ingresa una categoría. Consulta su documentación para una lista: https://waifu.pics/docs.
 - Para la pestaña "Anime Booru":
-  - `/yandere` para cambiar al modo yande.re (para imágenes generales) [Por defecto].
+  - `/mode yandere` para cambiar al modo yande.re (para imágenes generales) [Por defecto].
   - `/konachan` para cambiar a Konachan (para fondos de pantalla).
   - Ingresa etiquetas separadas por espacios y obtendrás 20 imágenes (por defecto, configurable).
   - Incluye un número para ir a esa página.

--- a/src/content/docs/es/ii-ags/02.usage.mdx
+++ b/src/content/docs/es/ii-ags/02.usage.mdx
@@ -17,7 +17,7 @@ Primero, para una lista de atajos de teclado, presiona `Super`+`/`.
 
 También incluye algunas Acciones para el lanzador.
 
-## Resumen/lanzador
+## Vista general/lanzador de aplicaciones
 Presiona `Super` o `Super`+`Tab` para abrir.
 
 - **Ventanas**
@@ -34,7 +34,7 @@ Presiona `Super` o `Super`+`Tab` para abrir.
   - <u>Acciones</u>: Cada acción comienza con un `>`. Consulta la **hoja de trucos de atajos de teclado** para una lista
   - <u>Aplicaciones</u> por defecto, ¡por supuesto!
 
-## Controles de la barra
+## Controles de la barra principal
 - Medios:
   - Esquina superior derecha
     - Clic medio: reproducir/pausar medios
@@ -117,13 +117,13 @@ La Agrupación de Espacios de Trabajo introduce un sistema flexible que permite 
 Si deseas modificar los atajos de teclado o incluir [más funciones](https://wiki.hyprland.org/Configuring/Dispatchers/) para la navegación de espacios de trabajo, usa el script `${HOME}/.config/ags/scripts/hyprland/workspace_action.sh`, en lugar de `hyprctl dispatch`. Esto determinará el grupo de espacios de trabajo actual usando el ID del espacio de trabajo activo y despachará al espacio de trabajo adecuado.
 :::
 
-## Consideraciones Multi-Monitor
+## Consideraciones para múltiples monitores
 
-Considera estas estrategias para una gestión efectiva de múltiples monitores:
-- Asigna el grupo 1 (espacios de trabajo 1-10) al monitor principal mientras que el grupo 2 (espacios de trabajo 11-20) al monitor secundario.
-  - Al iniciar, mueve manualmente el espacio de trabajo inicial en el monitor secundario al segundo grupo (por ejemplo, espacio de trabajo 11) usando `Super` + `0`, luego `Ctrl` + `Super` + `Derecha`.
-  - En efecto, esto también creará un widget de resumen separado por monitor.
-- Usa [vinculación de espacios de trabajo](https://wiki.hyprland.org/Configuring/Workspace-Rules/#rules) para colocar siempre espacios de trabajo específicos en monitores específicos. Obtén todos los nombres de tus monitores usando `hyprctl monitors | grep Monitor`.
+Considera estas estrategias para la gestión eficaz de múltiples monitores:
+- Asigna el grupo 1 (espacios de trabajo 1-10) al monitor principal y el grupo 2 (espacios de trabajo 11-20) al monitor secundario:
+  - Al iniciar el sistema, mueve manualmente el espacio de trabajo inicial del monitor secundario al segundo grupo (por ejemplo, espacio de trabajo 11) usando `Super` + `0`, y luego `Ctrl` + `Super` + `Derecha`.
+  - Esto también creará un widget de vista general independiente para cada monitor.
+- Usa la [vinculación de espacios de trabajo](https://wiki.hypr.land/Configuring/Workspace-Rules/#rules) para colocar siempre espacios de trabajo específicos en monitores específicos. Obtén los nombres de todos tus monitores usando `hyprctl monitors | grep Monitor`.
   ```ini title="~/.config/custom/general.conf"
   # Vincula espacios de trabajo 1-10 (grupo 1) al monitor principal
   workspace = 1, monitor:eDP-1, default:true

--- a/src/content/docs/es/ii-ags/03.config.mdx
+++ b/src/content/docs/es/ii-ags/03.config.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuración
 layout: /src/layouts/autonum.astro
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 :::caution
@@ -14,10 +14,10 @@ Una nueva incidencia de la versión AGS probablemente se cierre por no estar pre
 
 # Configurando Hyprland
 Lo siguiente y muchas otras cosas son impulsadas por Hyprland.
-- combinaciones de teclas globales
-- variables de entorno
-- pantallas/monitores/espacios de trabajo
-- animaciones/decoraciones de ventanas
+- Atajos de teclado globales.
+- Variables de entorno.
+- Pantallas/monitores/espacios de trabajo.
+- Animaciones/decoraciones de ventanas.
 - ...
 
 Referencia: [Hyprland Wiki](https://wiki.hyprland.org/)
@@ -45,22 +45,22 @@ windowrule = noblur,.*  # Desactiva el desenfoque para ventanas. Mejora sustanci
 
 # Configurando AGS
 Lo siguiente y algunas otras cosas son impulsadas por AGS.
-- barra principal
-- barras laterales
-- hoja de trucos
-- notificación
-- widget de vista general
+- Barra principal.
+- Barras laterales.
+- Hoja de trucos.
+- Notificación.
+- Widget de vista general.
 
 ## Para usuarios finales
 Edita `~/.config/ags/user_options.jsonc`, que no será sobrescrito por `install.sh` cuando actualices.
 Puedes configurar cosas como:
-- Proveedor predeterminado de asistente tipo ChatGPT
-- Velocidad de animación
-- Formato de hora
+- Proveedor predeterminado de asistente tipo ChatGPT.
+- Velocidad de animación.
+- Formato de hora.
 - ...
 
 :::note
-Para configuraciones que no están limitadas a AGS, consulta la sección "Misc".
+Para configuraciones que no están limitadas a AGS, consulta la sección "Varios".
 :::
 ### Configurar formato de fecha y hora
 
@@ -78,7 +78,7 @@ Si no estás seguro del nombre de la ciudad,
 como usamos [wttr.in](https://github.com/chubin/wttr.in) para proporcionar información meteorológica, puedes encontrar la respuesta allí.
 :::
 
-### Configurar combinaciones de teclas
+### Configurar atajos de teclado
 Las combinaciones de teclas a configurar son limitadas y necesitas consultar el documento de gdk para conocer las teclas, pero funciona.
 
 Consulta [#5](https://github.com/end-4/dots-hyprland-wiki/issues/5) para más información.
@@ -108,12 +108,12 @@ chmod +x ~/.cache/ags/user/scripts/*.sh
 :::
 
 Para más personalización:
-- Intervalo de sondeo, en milisegundos: `~/.cache/ags/user/scripts/custom-module-interval.txt` (predeterminado = 5000)
-- Script de acción de clic izquierdo: `~/.cache/ags/user/scripts/custom-module-leftclick.sh`
-- Script de acción de clic derecho: `~/.cache/ags/user/scripts/custom-module-rightclick.sh`
+- Intervalo de sondeo, en milisegundos: `~/.cache/ags/user/scripts/custom-module-interval.txt` (predeterminado = 5000).
+- Script de acción de clic izquierdo: `~/.cache/ags/user/scripts/custom-module-leftclick.sh`.
+- Script de acción de clic derecho: `~/.cache/ags/user/scripts/custom-module-rightclick.sh`.
 ## Para nerds (dudamos que no lo seas)
-- Consulta [AGS Docs](https://aylur.github.io/ags-docs)
-- También notas de desarrollo (consulta la barra lateral)
+- Consulta [AGS Docs](https://aylur.github.io/ags-docs).
+- También notas de desarrollo (consulta la barra lateral).
 
 
 # Varios
@@ -157,6 +157,6 @@ Como resultado, `loginctl lock-session` llamará a `swaylock` para bloquear la p
 El comando `loginctl lock-session` enviará una señal al proceso `hypridle` en ejecución, y luego `hypridle` ejecutará el comando a partir del valor de `$lock_cmd`.
 :::
 ## Cloudflare WARP
-- Esto podría ayudarte a evitar las restricciones de tu ISP y proporcionar una internet más rápida
-- Habrá un botón en la barra lateral derecha para activar/desactivar WARP si está instalado
-- Para instalar Cloudflare WARP, ejecuta `yay -S cloudflare-warp-bin && sudo systemctl enable warp-svc --now`
+- Esto podría ayudarte a evitar las restricciones de tu ISP y proporcionar una internet más rápida.
+- Habrá un botón en la barra lateral derecha para activar/desactivar WARP si está instalado.
+- Para instalar Cloudflare WARP, ejecuta `yay -S cloudflare-warp-bin && sudo systemctl enable warp-svc --now`.

--- a/src/content/docs/es/ii-ags/03.config.mdx
+++ b/src/content/docs/es/ii-ags/03.config.mdx
@@ -45,7 +45,7 @@ windowrule = noblur,.*  # Desactiva el desenfoque para ventanas. Mejora sustanci
 
 # Configurando AGS
 Lo siguiente y algunas otras cosas son impulsadas por AGS.
-- barra superior
+- barra principal
 - barras laterales
 - hoja de trucos
 - notificación

--- a/src/content/docs/es/ii-ags/03.config.mdx
+++ b/src/content/docs/es/ii-ags/03.config.mdx
@@ -1,8 +1,16 @@
 ---
 title: Configuración
 layout: /src/layouts/autonum.astro
-lastUpdated: 2025-04-03
+lastUpdated: 2026-07-07
 ---
+
+:::caution
+La versión AGS de illogical impulse ya no recibe soporte.
+
+Aunque aún podría funcionar, tendrás que solucionar los problemas por tu cuenta.
+
+Una nueva incidencia de la versión AGS probablemente se cierre por no estar previsto.
+:::
 
 # Configurando Hyprland
 Lo siguiente y muchas otras cosas son impulsadas por Hyprland.
@@ -65,6 +73,11 @@ En su lugar, aparecerá un widget del clima en esta posición.
 
 La ciudad para el clima se detecta por `curl ipinfo.io` de forma predeterminada, o se establece explícitamente en `~/.config/ags/user_options.jsonc`.
 
+:::note
+Si no estás seguro del nombre de la ciudad,
+como usamos [wttr.in](https://github.com/chubin/wttr.in) para proporcionar información meteorológica, puedes encontrar la respuesta allí.
+:::
+
 ### Configurar combinaciones de teclas
 Las combinaciones de teclas a configurar son limitadas y necesitas consultar el documento de gdk para conocer las teclas, pero funciona.
 
@@ -104,7 +117,7 @@ Para más personalización:
 
 
 # Varios
-## Cambiar el tamaño de la interfaz / cambiar el tamaño de la fuente
+## Cambiar el tamaño de la interfaz / de la fuente
 Cambiar el tamaño de la fuente también cambiará la escala de la interfaz para AGS.
 - Usando `gsettings`:
 ```bash
@@ -115,12 +128,34 @@ gsettings set org.gnome.desktop.interface font-name 'Rubik 11'
 ```
 
 ## Configurar pantalla de bloqueo
+### Bloqueo automático de pantalla
 Referencia: [Hyprland Wiki](https://wiki.hyprland.org/Hypr-Ecosystem/hyprlock/)
 
-Edita `~/.config/hypr/hyprlock.conf`.
+Edita `~/.config/hypr/hyprlock.conf` según tus necesidades.
+### Hyprlock personalizado
+Referencia: [Hyprland Wiki](https://wiki.hyprland.org/Hypr-Ecosystem/hyprlock/)
+
+Hyprlock es el proveedor de bloqueo de pantalla predeterminado.
+
+Edita `~/.config/hypr/hyprlock.conf` según tus necesidades.
 
 Por ejemplo, para configurar el formato de fecha y hora, cambia el valor del `text` **que corresponde al bloqueo**.
+### Usar otro proveedor de bloqueo de pantalla
+Referencia: [Arch Wiki](https://wiki.archlinux.org/title/Session_lock)
 
+Tomemos `swaylock` como ejemplo.
+
+Edita `~/.config/hypr/hypridle.conf` y modifica el valor de `$lock_cmd` de la siguiente manera:
+```ini
+$lock_cmd = swaylock
+```
+Asegúrate de que hypridle esté ejecutándose (normalmente se iniciará automáticamente si tienes `exec-once = hypridle` en la configuración de Hyprland).
+
+Como resultado, `loginctl lock-session` llamará a `swaylock` para bloquear la pantalla.
+
+:::note[Cómo]
+El comando `loginctl lock-session` enviará una señal al proceso `hypridle` en ejecución, y luego `hypridle` ejecutará el comando a partir del valor de `$lock_cmd`.
+:::
 ## Cloudflare WARP
 - Esto podría ayudarte a evitar las restricciones de tu ISP y proporcionar una internet más rápida
 - Habrá un botón en la barra lateral derecha para activar/desactivar WARP si está instalado

--- a/src/content/docs/es/ii-ags/04.troubleshooting.mdx
+++ b/src/content/docs/es/ii-ags/04.troubleshooting.mdx
@@ -67,14 +67,14 @@ Y recuerda reemplazar `<username>` por tu nombre de usuario.
 
 ## Cómo obtener registros
 - Si hay algún problema, abre una terminal (`Super`+`T`) y ejecuta el comando en la consola. Busca errores o advertencias que puedan ser problemáticos.
-- La barra, las barras laterales, la hoja de trucos, etc., funcionan con AGS. (Consejo: No es Waybar). Abre una terminal y ejecuta `pkill agsv1; agsv1`.
+- La barra principal, las barras laterales, la hoja de trucos, etc., funcionan con AGS. (Consejo: No es Waybar). Abre una terminal y ejecuta `pkill agsv1; agsv1`.
 
 ## Información adicional
 - Busca en esta wiki (especialmente en esta página), así como en los [incidentes](https://github.com/end-4/dots-hyprland/issues) y [discusiones](https://github.com/end-4/dots-hyprland/discussions) existentes.
 - Usa el sentido común. Si no encuentras la solución, [abre una discusión](https://github.com/end-4/dots-hyprland/discussions) para obtener ayuda.
 
 # Algunos problemas y soluciones/alternativas
-## Problemas con AGS, tema/íconos/CSS de barras no funciona
+## Problemas con AGS, tema/íconos/CSS de barras no funcionan
 > Referencia: [end-4/dots-hyprland#1010](https://github.com/end-4/dots-hyprland/issues/1010)
 
 Cambia el fondo de pantalla pulsando `Super+Ctrl+T` y seleccionando una imagen en la ventana emergente.

--- a/src/content/docs/es/ii-ags/04.troubleshooting.mdx
+++ b/src/content/docs/es/ii-ags/04.troubleshooting.mdx
@@ -1,27 +1,132 @@
 ---
 title: Solución de problemas
 layout: /src/layouts/autonum.astro
-lastUpdated: 2024-12-13
+lastUpdated: 2026-07-07
 ---
 
-:::tip[Consejo]
-Presiona `Ctrl`+`F` para buscar o consulta la barra lateral derecha para encontrar tu problema.
+:::caution
+La versión AGS de illogical impulse ya no recibe soporte.
+
+Aunque aún podría funcionar, tendrás que solucionar los problemas por tu cuenta.
+
+Una nueva incidencia de la versión AGS probablemente se cierre por no estar previsto.
 :::
 
-# Pistas
+:::tip
+En esta página, presiona `Ctrl`+`F` para buscar o ve la barra lateral derecha para encontrar tu problema.
+:::
 
-- Si hay un problema con algo, lo primero que debes hacer es abrir una terminal (`Super`+`T`) y ejecutarlo. Busca errores/advertencias que puedan ser problemáticos.
-- La barra, las barras laterales, la hoja de trucos, etc. son impulsados por AGS. Abre una terminal y ejecuta `pkill ags; ags`.
+# Lectura obligatoria
+## Requisito previo para la variable de entorno
+:::note
+Ya hemos dado un aviso relacionado en `install.sh`, pero algunos usuarios lo ignoraron al reportar problemas.
+:::
 
-> Usa el sentido común. Si no puedes resolverlo, [abre una discusión](https://github.com/end-4/dots-hyprland/discussions) para obtener ayuda.
+La variable de entorno `$ILLOGICAL_IMPULSE_VIRTUAL_ENV` debe estar configurada correctamente; de ​​lo contrario, la configuración de AGS no funcionará.
 
-# Algunos problemas
+Hemos creado una configuración predeterminada en `~/.config/hypr/hyprland/env.conf`, pero debes asegurarte de que este archivo de configuración esté incluido en `~/.config/hypr/hyprland.conf`. A menudo es necesario reiniciar Hyprland.
+
+Puedes ejecutar `./diagnose` para verificar su valor.
+
+### Ejemplo esperado
+```
+[===diagnose===] declare -p ILLOGICAL_IMPULSE_VIRTUAL_ENV
+declare -x ILLOGICAL_IMPULSE_VIRTUAL_ENV="/home/<username>/.local/state/ags/.venv"
+[---SUCCESS---]
+```
+Donde `<username>` representa el nombre de usuario.
+
+### Ejemplo inesperado 1
+```
+[===diagnose===] declare -p ILLOGICAL_IMPULSE_VIRTUAL_ENV
+./diagnose: line 30: declare: ILLOGICAL_IMPULSE_VIRTUAL_ENV: not found
+[---EXIT 1---]
+```
+Para el caso anterior:
+- Es muy probable que aún estés usando el archivo `~/.config/hypr/hyprland.conf` antiguo y hayas olvidado reemplazar su contenido con `~/.config/hypr/hyprland.conf.new`. Simplemente ejecuta `cd ~/.config/hypr;mv hyprland.conf{,.old};mv hyprland.conf{.new,}`.
+- Asegúrate de haber reiniciado Hyprland.
+
+### Ejemplo inesperado 2
+```
+[===diagnose===] declare -p ILLOGICAL_IMPULSE_VIRTUAL_ENV
+declare -x ILLOGICAL_IMPULSE_VIRTUAL_ENV="\$XDG_STATE_HOME/ags/.venv"
+[---SUCCESS---]
+```
+En el caso anterior, `$XDG_STATE_HOME` no se expande, lo cual resulta muy extraño (¿quizás un error de Hyprland?).
+- Asegúrate de que al ejecutar `install.sh`, no hayas omitido y hayas ejecutado correctamente `install-python-packages()`, lo que debería generar un directorio `~/.local/state/ags/.venv` no vacío.
+- Puedes especificar su valor directamente en `~/.config/hypr/custom/env.conf` de la siguiente manera:
+```ini
+env = ILLOGICAL_IMPULSE_VIRTUAL_ENV, /home/<username>/.local/state/ags/.venv
+```
+Y recuerda reemplazar `<username>` por tu nombre de usuario.
+
+## Acciones que deberías probar al menos una vez
+- Reinicia Hyprland o tu sistema, lo cual es necesario para aplicar los cambios en las variables de entorno.
+- Si hay problemas con AGS (por ejemplo, las "barras"), cambia el fondo de pantalla pulsando `Super+Ctrl+T` y seleccionando una imagen en la ventana emergente. Sin embargo, no siempre es efectivo, especialmente si el problema está en la instalación o en las variables de entorno.
+- El script `install.sh` es idempotente. Puedes ejecutarlo cuando quieras.
+
+## Cómo obtener registros
+- Si hay algún problema, abre una terminal (`Super`+`T`) y ejecuta el comando en la consola. Busca errores o advertencias que puedan ser problemáticos.
+- La barra, las barras laterales, la hoja de trucos, etc., funcionan con AGS. (Consejo: No es Waybar). Abre una terminal y ejecuta `pkill agsv1; agsv1`.
+
+## Información adicional
+- Busca en esta wiki (especialmente en esta página), así como en los [incidentes](https://github.com/end-4/dots-hyprland/issues) y [discusiones](https://github.com/end-4/dots-hyprland/discussions) existentes.
+- Usa el sentido común. Si no encuentras la solución, [abre una discusión](https://github.com/end-4/dots-hyprland/discussions) para obtener ayuda.
+
+# Algunos problemas y soluciones/alternativas
+## Problemas con AGS, tema/íconos/CSS de barras no funciona
+> Referencia: [end-4/dots-hyprland#1010](https://github.com/end-4/dots-hyprland/issues/1010)
+
+Cambia el fondo de pantalla pulsando `Super+Ctrl+T` y seleccionando una imagen en la ventana emergente.
+
+## Falta el ícono de alguna aplicación en el dock/vista general
+> Referencia: [end-4/dots-hyprland#497 comentario](https://github.com/end-4/dots-hyprland/issues/497#issuecomment-2108212444) [end-4/dots-hyprland#487](https://github.com/end-4/dots-hyprland/issues/487)
+
+Pruebe las siguientes soluciones/alternativas:
+### Usa `gsettings` para configurar el tema de íconos
+:::note
+Esto es adecuado para la siguiente situación:
+- La clase de la ventana de la aplicación tiene un ícono idéntico en el tema de íconos A, pero no en el B.
+- Está usando el tema de íconos B, lo que significa que el problema se resuelve al cambiar al tema de íconos A.
+:::
+
+Por ejemplo, [Papirus](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme) (recomendado, ya que abarca muchas aplicaciones):
+```sh
+gsettings set org.gnome.desktop.interface icon-theme Papirus
+```
+Por supuesto, primero debes instalarlo. Para Arch Linux, usa `sudo pacman -S papirus-icon-theme`.
+
+### Configurar sustituciones en `user_options.jsonc` de AGS
+:::note
+Esto es adecuado para la siguiente situación:
+- La aplicación tiene más de un nombre de clase de ventana (por ejemplo, `foot` y `footclient`), pero solo uno de ellos (por ejemplo, `foot`) tiene un ícono idéntico en el tema de íconos actual.
+- Estás de acuerdo en usar el mismo ícono para esas diferentes clases de ventana (por ejemplo, el mismo ícono para `foot` y `footclient`).
+:::
+
+Edita `~/.config/ags/user_options.jsonc` y añade una entrada dentro de `icons.substitutions`, por ejemplo:
+```js
+'icons': {
+    substitutions: {
+        'footclient': "foot",
+    },
+},
+```
+
+:::note
+Si es la primera vez que editas este archivo, consulta primero las instrucciones al principio de `user_options.jsonc`.
+:::
+
+### Configurar la ruta de búsqueda de íconos
+Esto es adecuado si tienes el archivo de íconos por separado.
+
+Modifica correctamente el archivo `icons.searchPaths` dentro de `~/.config/ags/user_options.jsonc`.
 
 ## Los controles de música no aparecen
+
 > Referencia: [end-4/dots-hyprland#168](https://github.com/end-4/dots-hyprland/issues/168)
 
 - Asegúrate de que tu reproductor tenga soporte Mpris (una lista: [Enlace de Arch Wiki](https://wiki.archlinux.org/title/MPRIS)).
-- Si es un navegador, instala la extensión de Integración de Plasma: [Firefox](https://addons.mozilla.org/en-US/firefox/addon/plasma-integration/) o [Chromium](https://chrome.google.com/webstore/detail/plasma-integration/cimiefiiaegbelhefglklhhakcgmhkai) y `plasma-browser-integration` (esto es para Arch).
+- Si es un navegador, instala la extensión de Plasma Integration: [Firefox](https://addons.mozilla.org/en-US/firefox/addon/plasma-integration/) o [Chromium](https://chrome.google.com/webstore/detail/plasma-integration/cimiefiiaegbelhefglklhhakcgmhkai) y `plasma-browser-integration` (esto es para Arch).
 
 Luego, cuando Firefox esté reproduciendo medios, el siguiente comando
 ```bash
@@ -40,29 +145,10 @@ considera los siguientes pasos:
 3. Reinicia Firefox con el nuevo perfil y vuelve a intentarlo.
 - _Nota: `playerctl -F metadata` también puede ser útil para la depuración._
 
-## Los iconos no aparecen. Obtengo textos extraños en su lugar.
+## Los íconos no aparecen. Obtengo textos extraños en su lugar.
 - Debes estar perdiendo la fuente Material Symbols. Puedes descargar la fuente manualmente y luego ponerla en `~/.local/share/fonts`.
 - ¡Ten en cuenta que es Material <u>**Symbols**</u>, no Material <u>**Icons**</u>!
 - Recuerda ejecutar `fc-cache -fv` para actualizar la caché de fuentes. Un reinicio también funcionará.
-
-## La instalación de AGS falló
-### `PermissionError: [Errno 13] Permission denied: '/usr/local/lib/libgvc.so'`
-Ejecuta esto para verificar si este archivo pertenece a algún paquete (muy probablemente no, porque está dentro de `/usr/local`)
-```bash
-pacman -Qo /usr/local/lib/libgvc.so
-```
-Si no, entonces probablemente sea seguro simplemente eliminarlo. Para hacerlo, ejecuta esto:
-```bash
-sudo mv /usr/local/lib/libgvc.so /tmp/
-```
-
-### Otros errores
-Elimina `./cache/ags` e instálalo nuevamente.
-
-## La instalación de Hyprland falló
-A veces el paquete AUR no instala todas las dependencias por ti. Hyprland siempre está evolucionando y esto sucede cuando se agrega algo nuevo.
-- Revisa los registros y verifica si te dice que instales algo, luego intenta construirlo nuevamente.
-- Nota: Es posible que tengas que limpiar `~/.cache/yay`.
 
 ## `loginctl lock-session` no hace nada
 > Referencia: [end-4/dots-hyprland#278](https://github.com/end-4/dots-hyprland/issues/278)
@@ -81,3 +167,32 @@ Consulta [Hyprland Wiki](https://wiki.hyprland.org/Hypr-Ecosystem/hypridle/#conf
 - ¿No quieres esto?
   - Para eliminar esta vinculación: en `~/.config/foot/foot.ini`, comenta o elimina la línea que dice `clipboard-copy=Control+c`.
   - Tal vez si usas aplicaciones de terminal mucho, sería una buena idea usar una terminal más rica en funciones.
+
+## Congelamiento aleatorio
+:::note
+Esto no está relacionado técnicamente con ilogical-impulse.
+:::
+Ver https://github.com/end-4/dots-hyprland/issues/746 .
+
+# Problemas, soluciones y alternativas obsoletas
+El contenido a continuación ya no es útil porque se han producido cambios.
+
+Aun así, lo mantenemos aquí por si lo necesitamos de nuevo en el futuro.
+## La instalación de AGS falló
+### `PermissionError: [Errno 13] Permission denied: '/usr/local/lib/libgvc.so'`
+Ejecuta esto para verificar si este archivo pertenece a algún paquete (muy probablemente no, porque está dentro de `/usr/local`)
+```bash
+pacman -Qo /usr/local/lib/libgvc.so
+```
+Si no, entonces probablemente sea seguro simplemente eliminarlo. Para hacerlo, ejecuta esto:
+```bash
+sudo mv /usr/local/lib/libgvc.so /tmp/
+```
+
+### Otros errores
+Elimina `./cache/ags` e instálalo nuevamente.
+
+## La instalación de Hyprland falló
+A veces el paquete AUR no instala todas las dependencias por ti. Hyprland siempre está evolucionando y esto sucede cuando se agrega algo nuevo.
+- Revisa los registros y verifica si te dice que instales algo, luego intenta construirlo nuevamente.
+- Nota: Es posible que tengas que limpiar `~/.cache/yay`.

--- a/src/content/docs/es/ii-ags/04.troubleshooting.mdx
+++ b/src/content/docs/es/ii-ags/04.troubleshooting.mdx
@@ -170,7 +170,7 @@ Consulta [Hyprland Wiki](https://wiki.hyprland.org/Hypr-Ecosystem/hypridle/#conf
 
 ## Congelamiento aleatorio
 :::note
-Esto no está relacionado técnicamente con ilogical-impulse.
+Esto no está relacionado técnicamente con illogical-impulse.
 :::
 Ver https://github.com/end-4/dots-hyprland/issues/746 .
 

--- a/src/content/docs/es/ii-ags/04.troubleshooting.mdx
+++ b/src/content/docs/es/ii-ags/04.troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Solución de problemas
 layout: /src/layouts/autonum.astro
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 :::caution
@@ -31,10 +31,10 @@ Puedes ejecutar `./diagnose` para verificar su valor.
 ### Ejemplo esperado
 ```
 [===diagnose===] declare -p ILLOGICAL_IMPULSE_VIRTUAL_ENV
-declare -x ILLOGICAL_IMPULSE_VIRTUAL_ENV="/home/<username>/.local/state/ags/.venv"
+declare -x ILLOGICAL_IMPULSE_VIRTUAL_ENV="/home/user/.local/state/ags/.venv"
 [---SUCCESS---]
 ```
-Donde `<username>` representa el nombre de usuario.
+Donde `user` es tu nombre de usuario.
 
 ### Ejemplo inesperado 1
 ```
@@ -56,9 +56,9 @@ En el caso anterior, `$XDG_STATE_HOME` no se expande, lo cual resulta muy extra�
 - Asegúrate de que al ejecutar `install.sh`, no hayas omitido y hayas ejecutado correctamente `install-python-packages()`, lo que debería generar un directorio `~/.local/state/ags/.venv` no vacío.
 - Puedes especificar su valor directamente en `~/.config/hypr/custom/env.conf` de la siguiente manera:
 ```ini
-env = ILLOGICAL_IMPULSE_VIRTUAL_ENV, /home/<username>/.local/state/ags/.venv
+env = ILLOGICAL_IMPULSE_VIRTUAL_ENV, /home/user/.local/state/ags/.venv
 ```
-Y recuerda reemplazar `<username>` por tu nombre de usuario.
+Y recuerda reemplazar `user` por tu nombre de usuario.
 
 ## Acciones que deberías probar al menos una vez
 - Reinicia Hyprland o tu sistema, lo cual es necesario para aplicar los cambios en las variables de entorno.
@@ -154,11 +154,11 @@ considera los siguientes pasos:
 > Referencia: [end-4/dots-hyprland#278](https://github.com/end-4/dots-hyprland/issues/278)
 
 Según [esta publicación en los foros de Arch Linux](https://bbs.archlinux.org/viewtopic.php?pid=1311990#p1311990):
-> Algo necesita escuchar las señales dbus de systemd-logind para que esto funcione.
+> Para que esto funcione, es necesario que algo escuche las señales dbus de systemd-logind.
 
-Hypridle es capaz de ser esta "cosa", lo que significa que debes asegurarte de que esté ejecutándose,
-y luego `loginctl lock-session` enviará una señal a hypridle,
-como resultado hypridle bloqueará la pantalla ejecutando el `$lock_cmd` definido en su configuración `~/.config/hypr/hypridle.conf`.
+Hypridle puede ser ese "algo", lo que significa que debes asegurarte de que esté en ejecución,
+y luego `loginctl lock-session` enviará una señal a hypridle.
+Como resultado, hypridle bloqueará la pantalla ejecutando `$lock_cmd` definido en su configuración `~/.config/hypr/hypridle.conf`.
 
 Consulta [Hyprland Wiki](https://wiki.hyprland.org/Hypr-Ecosystem/hypridle/#configuration) para más información.
 

--- a/src/content/docs/es/ii-ags/05.faq.mdx
+++ b/src/content/docs/es/ii-ags/05.faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: Preguntas aleatorias
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 :::caution
@@ -14,7 +14,7 @@ Una nueva incidencia de la versión AGS probablemente se cierre por no estar pre
 _Para problemas de uso, consulte la página de Solución de problemas. Esta página es para ~~tonterías~~ asuntos generales._
 
 ---
-- **P: Tu configuración está sobrecargada**
+- **P: Tu configuración está sobrecargada.**
 - R: No la ejecutes en basura electrónica. Además, el minimalismo extremo es en realidad un esfuerzo mínimo.
 ---
 - **P: ¿Por qué no describes tus dotfiles como "estéticos"?**

--- a/src/content/docs/es/ii-ags/05.faq.mdx
+++ b/src/content/docs/es/ii-ags/05.faq.mdx
@@ -1,12 +1,18 @@
 ---
-title: FAQ
-lastUpdated: 2024-12-13
+title: Preguntas aleatorias
+lastUpdated: 2026-07-07
 ---
-_Para problemas de uso, consulte la página de Solución de problemas. Esta página es para asuntos generales._
 
----
-- **P: ¿Por qué usar `hyprland-git` de AUR en lugar de `hyprland` del repositorio de Arch Linux?**
-- R: end_4 a veces contribuye y le gusta eso (referencia: [#158](https://github.com/end-4/dots-hyprland/issues/158#issuecomment-1872424355))
+:::caution
+La versión AGS de illogical impulse ya no recibe soporte.
+
+Aunque aún podría funcionar, tendrás que solucionar los problemas por tu cuenta.
+
+Una nueva incidencia de la versión AGS probablemente se cierre por no estar previsto.
+:::
+
+_Para problemas de uso, consulte la página de Solución de problemas. Esta página es para ~~tonterías~~ asuntos generales._
+
 ---
 - **P: Tu configuración está sobrecargada**
 - R: No la ejecutes en basura electrónica. Además, el minimalismo extremo es en realidad un esfuerzo mínimo.
@@ -14,6 +20,6 @@ _Para problemas de uso, consulte la página de Solución de problemas. Esta pág
 - **P: ¿Por qué no describes tus dotfiles como "estéticos"?**
 - R: Para ricing, ¿no es un sinónimo de "inaccesibilidad"?
 ---
-- **P: ¿Cuándo agregarás [Función X]?**
-- R: Abre un issue
+- **P: ¿Cuándo agregarás [Funcionalidad X]?**
+- R: Posiblemente nunca, pero pregunta.
 ---

--- a/src/content/docs/es/ii-qs/00.description.mdx
+++ b/src/content/docs/es/ii-qs/00.description.mdx
@@ -1,0 +1,13 @@
+---
+title: Introducción
+sidebar:
+  label: Introducción
+lastUpdated: 2026-07-07
+---
+
+## Qué esperar
+
+- **Aplicaciones Qt en vez de GTK**. Estas últimas conservan el tema correcto, pero no se usan por defecto.
+- **Material Design 3** como lenguaje de diseño.
+- **Atajos de teclado familiares** para quienes vienen de Windows o GNOME. Sin combinaciones tipo Vim.
+- **Carácter prescriptivo**: Esto se da por sentado en los *dotfiles*.

--- a/src/content/docs/es/ii-qs/00.description.mdx
+++ b/src/content/docs/es/ii-qs/00.description.mdx
@@ -10,4 +10,4 @@ lastUpdated: 2026-07-07
 - **Aplicaciones Qt en vez de GTK**. Estas últimas conservan el tema correcto, pero no se usan por defecto.
 - **Material Design 3** como lenguaje de diseño.
 - **Atajos de teclado familiares** para quienes vienen de Windows o GNOME. Sin combinaciones tipo Vim.
-- **Carácter prescriptivo**: Esto se da por sentado en los *dotfiles*.
+- **Carácter prescriptivo**: Esto se da por sentado en los dotfiles.

--- a/src/content/docs/es/ii-qs/01.setup.mdx
+++ b/src/content/docs/es/ii-qs/01.setup.mdx
@@ -1,0 +1,287 @@
+---
+title: Instalar/ Actualizar / Desinstalar
+layout: /src/layouts/autonum.astro
+lastUpdated: 2026-07-07
+---
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+# Instalación
+### Consejos
+- Solo se proporciona **la personalización a nivel de usuario**. Eres responsable del resto del software y la configuración necesaria para el funcionamiento básico de tu sistema.
+- **No es necesario reinstalar tu sistema.**
+
+
+### Métodos
+
+- [Automatizado](#automated-installation): con un script
+- [Manual](#manual-installation): clona y pega manualmente
+- [Forks de la comunidad](#forks): installación especializada para ciertas distribuciones
+- [Distribuciones de terceros](#3rd-party-distros): sistemas operativos que ofrecen illogical-impulse listo para usar
+
+:::tip[Migración de versión AGS]
+*Omite esto si no usas la versión antigua de AGS o averígüalo por tu cuenta si no usas Arch Linux*
+
+La versión Quickshell debería funcionar correctamente después de la instalación, pero puede desinstalar los paquetes antiguos antes de instalar los nuevos:
+
+```sh
+sudo pacman -Rs $(pacman -Q | grep "illogical-impulse-" | awk '{print $1}')
+```
+
+luego realiza la instalación.
+:::
+
+## Instalación automatizada
+
+:::caution[¿Hyprland 0.55?]
+Si tu distribución no incluye Hyprland 0.55 y/o no estás preparado para ello, deberías cambiar a la versión previa a la integración de Lua en Hyprland. Ejemplo de instalación:
+```
+git clone --recursive https://github.com/end-4/dots-hyprland && cd dots-hyprland && git checkout 2026.05.11 && ./setup install
+```
+:::
+
+### Compatibilidad en distribuciones
+El script detecta automáticamente la distribución antes de continuar.
+Este es un resumen del estado de soporte de las distribuciones:
+- **Mantenido por desarrolladores:**
+  - [Arch Linux](https://archlinux.org/) y [EndeavourOS](https://endeavouros.com/) están bien mantenidas
+  - [CachyOS](https://cachyos.org/) debería de funcionar bien, aunque en casos raros las diferencias en paquetes pueden causar problemas para usuarios inexpertos. Lo mismo aplica a otras distribuciones basadas en Arch.
+- **Mantenido por la comunidad:**
+  - [Gentoo](https://www.gentoo.org/) (consulta [sdata/dist-gentoo/README.md](https://github.com/end-4/dots-hyprland/blob/main/sdata/dist-gentoo/README.md) para más información).
+  - [Fedora](https://fedoraproject.org/) (consulta [sdata/dist-fedora/README.md](https://github.com/end-4/dots-hyprland/blob/main/sdata/dist-fedora/README.md) para más información).
+  - Otras distribuciones: ¡Agradecemos las contribuciones! Consulta [esta página](../../dev/inst-script/#help-wanted) si deseas colaborar.
+- **En desarrollo:**
+  - El proyecto `dist-nix`, aún en desarrollo, intenta ofrecer compatibilidad entre distribuciones. Para distribuciones que utilizan paquetes relativamente antiguos, como [Debian](https://www.debian.org/), esta es prácticamente la única forma de instalar illogical-impulse. Consulta [#2382](https://github.com/end-4/dots-hyprland/discussions/2382) para probarlo.
+
+
+Usa cualquiera de los métodos a continuación. El primero es una alternativa más práctica al segundo, aunque cuestionable para algunas personas.
+
+<Tabs>
+<TabItem label="Usar script en línea">
+
+Ejecuta el siguiente comando:
+```bash
+bash <(curl -s https://ii.clsty.link/get)
+```
+
+Esto clona el repositorio en `~/.cache/dots-hyprland` por defecto y ejecuta `./setup install` por ti.
+
+### Avanzado: Personalizar instalación
+Para clonar en otro lugar, solo añade la ruta, por ejemplo:
+```bash
+bash <(curl -s https://ii.clsty.link/get) ~/Downloads/dots-hyprland
+```
+Para usar una instalación más minimalista que incluya principalmente Hyprland y Quickshell,
+pasa `--core` al script de instalación local (`./setup install`) ejecutando:
+```bash
+bash <(curl -s https://ii.clsty.link/get) -- --core
+```
+Para combinar los dos comportamientos anteriores, ejecuta:
+```bash
+bash <(curl -s https://ii.clsty.link/get) ~/Downloads/dots-hyprland -- --core
+```
+
+
+</TabItem>
+<TabItem label="Clona, cambia directorio y ejecuta">
+
+Ejecuta los siguientes comandos:
+```bash
+cd ~/.cache                                      # Tu elección, no importa
+git clone https://github.com/end-4/dots-hyprland # Clona el repositorio
+cd dots-hyprland                                 # Navega al repositorio clonado
+./setup install                                  # Ejecuta el script de instalación
+```
+
+### Instalación más minimalista
+Si deseas una instalación más minimalista que incluya principalmente Hyprland y Quickshell,
+ejecuta en su lugar `./setup install --core`.
+
+</TabItem>
+</Tabs>
+
+:::tip[Uso del subcomando: install]
+El subcomando `install` de `./setup` es idempotente e interactivo.
+
+Siempre puedes volver a ejecutar `./setup install` y elegir realizar solo ciertas acciones.
+
+Es útil cuando quieres reanudar un intento fallido o una actualización.
+:::
+
+## Forks
+Los siguientes enlaces son forks de la comunidad para otras distribuciones. **Estas se crearon cuando la compatibilidad entre distribuciones era limitada. Algunas de ellas son para la versión antigua de los *dotfiles* en AGS.**
+
+- NixOS
+  - Consulta [discusión #1093](https://github.com/end-4/dots-hyprland/discussions/1093)
+- OpenSUSE
+  - Consulta [discusión #485](https://github.com/end-4/dots-hyprland/discussions/485)
+  
+## Installación manual
+
+Para básicamente cualquier distribución
+
+:::caution
+Esta sección solo existe por demostración.
+
+Su uso no es recomendable en absoluto, ya que puede hacerte perder mucho tiempo.
+:::
+
+### Clona y navega al directorio
+
+```bash
+t=~/.cache/dots-hyprland   # No ensuciemos tu carpeta de inicio
+git clone https://github.com/end-4/dots-hyprland.git "$t" --filter=blob:none --recurse-submodules
+cd "$t"
+```
+
+### Instala las dependencias
+Para distribuciones basadas en Arch:
+- Instala todos los paquetes listados como valor del arreglo `depends` dentro de `./sdata/dist-arch/*/PKGBUILD`. Simplemente usa un gestor de paquetes AUR como `yay`.
+  - También puedes instalar alternativas adecuadas, según lo hayas descubierto.
+
+Para distribuciones no basadas en Arch:
+- Averigua los equivalentes de los paquetes listados en [deps-info.md](https://github.com/end-4/dots-hyprland/blob/main/sdata/deps-info.md) e instálalos.
+- Si has completado la instalación correctamente en alguna distribución no basada en Arch, puedes enviar un *PR*. Para más detalles, consulta [esta página](../../dev/inst-script/#help-wanted).
+
+### Configuración de permisos/servicios, etc.
+Lee el contenido de `sdata/subcmd-install/2.setups.sh`.
+- Si crees que todo está correcto, ejecuta `./setup install-setups`, que ejecutará este script.
+  - No ejecutes `sdata/subcmd-install/2.setups.sh` directamente, ya que debe ejecutarse mediante `./setup`.
+- O bien, ejecuta manualmente las líneas de este script con tus modificaciones.
+
+### Copiar archivos de configuración
+- Copia `dots/*` a tu carpeta `$HOME/` (revisa antes de hacerlo, ya que podrías sobrescribir tus propios archivos de configuración).
+- O bien, lee `sdata/subcmd-install/3.files.sh`.
+  - Si crees que todo está correcto, ejecuta `./setup install-files`, que ejecutará este script.
+  - No ejecutes `sdata/subcmd-install/3.files.sh` directamente, ya que debe ejecutarse con `./setup`.
+
+### Finalizar
+- Una vez que hayas terminado, inicia sesión de nuevo en Hyprland.
+  - `Ctrl`+`Super`+`T` para seleccionar un fondo de pantalla.
+  - `Super`+`/` para ver la lista de atajos de teclado. ¡Diviértete!
+
+## 3rd-party distros
+
+**Incluimos estas distribuciones aquí para tu información. No las respaldamos directamente y recomendamos actuar bajo tu criterio al seleccionar tu sistema operativo.**
+
+- [illogical-impulse-iso de El3ssar](https://github.com/El3ssar/illogical-impulse-iso): ISO de Arch que incluye illogical-impulse tal cual, sin modificaciones.
+
+# Después de la instalación
+## Detalles no tan opcionales
+
+### Evitar conflictos con daemons de notificación
+- Los daemons de notificación como `dunst` y `mako` pueden venir con las personalizaciones de tu distribución y pueden interferir con AGS si se inician primero. Se recomienda desinstalarlos si no los usas en otro lugar.
+
+### Evitar conflictos con AUR (solo en distribuciones basadas en Arch)
+El problema: Consulta [este comentario](https://github.com/end-4/dots-hyprland/discussions/3165#discussion-9788226).
+
+La solución: Edita manualmente tu archivo `/etc/pacman.conf` (no lo editaremos automáticamente, ya que es arriesgado) y añade:
+```conf
+IgnoreGroup=illogical-impulse
+```
+Consulta también [Arch Wiki - Pacman](https://wiki.archlinux.org/title/Pacman#Skip_package_group_from_being_upgraded) sobre la configuración de Pacman.
+
+## Detalles opcionales
+
+### Configuraciones adicionales
+
+Revisa si te interesa algo en la carpeta `dots-extra/`.
+
+### Integración de medios con el navegador
+
+Si quieres que la miniatura de medios de tu navegador se muestre, obtén la extensión "Plasma Integration".
+- Para [Chromium](https://chrome.google.com/webstore/detail/plasma-integration/cimiefiiaegbelhefglklhhakcgmhkai)
+- Para [Firefox](https://addons.mozilla.org/en-US/firefox/addon/plasma-integration/)
+
+### Esquema de colores para ZSH
+Pon esta línea en tu `~/.zshrc` para soportar el esquema de colores para ZSH:
+```bash
+source ~/.config/zshrc.d/dots-hyprland.zsh
+```
+
+## Iniciando Hyprland
+- Para iniciar Hyprland, puedes usar un gestor de pantalla (DM) o simplemente `tty`.
+- La wiki de Hyprland recomienda iniciar Hyprland con la sesión gestionada por uswm, pero yo no lo recomiendo. Usar esta opción no daña los *dotfiles*, pero ten en cuenta que podrías recibir mensajes no deseados de otros entornos de escritorio (por ejemplo, diálogos de autenticación duplicados).
+
+Consulta la [wiki de Hyprland](https://wiki.hyprland.org/Getting-Started/Master-Tutorial/#launching-hyprland) para obtener más detalles. A continuación, encontrarás algunos consejos adicionales.
+
+### ¿Cómo auto-iniciar Hyprland después de iniciar sesión en `tty1`?
+Para ZSH o BASH, agrega esta línea al **final** de tu `~/.zshrc` o `~/.bashrc`:
+```bash
+source ~/.config/zshrc.d/auto-Hypr.sh
+```
+
+Para FISH, agrega esta línea al **final** de tu `~/.config/fish/config.fish`:
+```fish
+source ~/.config/fish/auto-Hypr.fish
+```
+
+P.D. Se recomienda deshabilitar el DM si deseas iniciar Hyprland a través de tty.
+
+### Soy un novato. ¿Qué es un tty y DM?
+
+Aquí hay una breve introducción para darte un acceso rápido, aunque no exactamente cierto.
+
+Puedes ver `tty` como una especie de "base" de un sistema Linux.
+Normalmente hay 7 `tty`s: `tty1` a `tty7`. Puedes presionar `Ctrl+Alt+F<n>` para cambiar a `tty<n>`, y escribir tu nombre de usuario y contraseña para iniciar sesión.
+
+Después de iniciar sesión, puedes iniciar un entorno gráfico a través de un comando, por ejemplo, `Hyprland`.
+De hecho, la mayoría de las interfaces gráficas solo se pueden iniciar **después** de iniciar sesión.
+
+Pero, ¿qué pasa si queremos una interfaz gráfica para la propia interfaz de inicio de sesión?
+
+Entonces, aquí viene el DM (Display Manager, también llamado "LM", es decir, Login Manager).
+- Algunos DM comúnmente usados:
+  - `sddm`: A menudo usado con KDE Plasma.
+  - `gdm`: A menudo usado con Gnome.
+- Está habilitado a nivel del sistema y se inicia automáticamente después de arrancar el sistema (aún no iniciar sesión).
+  - En una distro basada en systemd, el DM generalmente está habilitado como un servicio systemd. Ejecuta lo siguiente para ver qué DM está habilitado.
+    ```bash
+    grep 'ExecStart=' /etc/systemd/system/display-manager.service
+    ```
+    Si devuelve `No such file or directory`, entonces no hay DM habilitado, o esta no es una distro basada en systemd.
+- Te proporciona una interfaz gráfica para iniciar sesión y elegir el entorno gráfico (por ejemplo, Hyprland).
+  - ¿Cómo sabe el DM qué entornos gráficos están disponibles?
+   - Normalmente, busca en la ruta `/usr/share/xsessions` para los de X11, y `/usr/share/wayland-sessions` para los de Wayland.
+   - Los archivos de escritorio bajo estos directorios contienen la información de los entornos gráficos.
+
+# Actualización
+
+:::caution[Actualización a Hyprland 0.55]
+Hyprland 0.55 introduce la configuración en Lua en lugar de Hyprlang. Si bien aún se puede usar el formato anterior, ya existen algunos cambios incompatibles con versiones anteriores debido a la reubicación de algunas variables. Hyprland solo te da dos meses para migrar a Lua.
+
+- Si decides seguir usando la versión 0.54 por ahora, consulta la nota "¿Hyprland 0.55?" en la sección de Instalación automatizada.
+- Si estás listo para la versión 0.55, sigue este procedimiento:
+  - Mueve la carpeta `~/.config/hypr/custom` a otra ubicación y elimínala.
+  - Ejecuta `git pull` y `./setup install` como de costumbre.
+  - Usando los archivos antiguos y los nuevos archivos de configuración proporcionados por los *dotfiles* como referencia, sobrescribe tus archivos de configuración antiguos en los nuevos archivos .lua.
+:::
+
+:::note[Resumen]
+Si usaste el script de instalación en línea en distribuciones basadas en Arch durante la instalación, puedes ejecutar el siguiente comando para actualizar:
+```bash
+cd ~/.cache/dots-hyprland && git stash && git pull && ./setup install
+```
+:::
+
+Por el momento, no tenemos de un verificador de actualizaciones ni un sistema de actualización automatizado. Dado que el script de instalación está diseñado para ser idempotente, para actualizar los *dotfiles*, deberás ejecutar el script de instalación nuevamente cada vez que desees actualizar, después de descargar los últimos cambios del repositorio.
+1. Navega al directorio del repositorio con `cd`. Por defecto, debería estar en `~/.cache/dots-hyprland`, a menos que hayas clonado el repositorio en otra ubicación.
+2. Ejecuta `git stash` para guardar los cambios locales. Idealmente, la instalación no debería modificar los archivos locales gestionados por Git, pero esto podría ocurrir inesperadamente, por lo que deberás guardarlos antes de descargar los últimos cambios.
+3. Ejecuta `git pull` para obtener y descargar los últimos cambios del repositorio.
+4. Ejecuta `./setup install` nuevamente.
+    - Omite los pasos que no deseas que el script actualice (especialmente los que utilizan `rsync ...`, ya que **sobrescribirán los archivos en su ruta de destino**). Normalmente, es posible que desees que se ejecute el paso `rsync` que involucra `dots/.config/quickshell`.
+
+:::tip
+Ejecuta `./setup install -h` para ver más usos.
+:::
+
+:::caution[Si realizaste la instalación manualmente]
+Aunque no se recomienda en absoluto, si lo instalaste manualmente:
+- Navega al directorio del repositorio con `cd` y ejecuta `git pull && git submodule update --init --recursive` para obtener los últimos cambios.
+- Asegúrate de que todas las dependencias estén instaladas, ya que la actualización puede incluir dependencias necesarias.
+- Descarga los archivos que necesites. Normalmente, querrás descargar la carpeta `dots/.config/quickshell`.
+:::
+
+
+# Uninstalling
+
+Just run `./setup uninstall`, but note that it's not perfect and not actively maintained so you need to choose carefully when answering the prompts.

--- a/src/content/docs/es/ii-qs/01.setup.mdx
+++ b/src/content/docs/es/ii-qs/01.setup.mdx
@@ -169,7 +169,7 @@ Lee el contenido de `sdata/subcmd-install/2.setups.sh`.
 ## Detalles no tan opcionales
 
 ### Evitar conflictos con daemons de notificación
-- Los daemons de notificación como `dunst` y `mako` pueden venir con las personalizaciones de tu distribución y pueden interferir con AGS si se inician primero. Se recomienda desinstalarlos si no los usas en otro lugar.
+- Los daemons de notificación como `dunst` y `mako` pueden venir con las personalizaciones de tu distribución y pueden interferir con Quickshell si se inician primero. Se recomienda desinstalarlos si no los usas en otro lugar.
 
 ### Evitar conflictos con AUR (solo en distribuciones basadas en Arch)
 El problema: Consulta [este comentario](https://github.com/end-4/dots-hyprland/discussions/3165#discussion-9788226).

--- a/src/content/docs/es/ii-qs/01.setup.mdx
+++ b/src/content/docs/es/ii-qs/01.setup.mdx
@@ -108,7 +108,7 @@ Es útil cuando quieres reanudar un intento fallido o una actualización.
 :::
 
 ## Forks
-Los siguientes enlaces son forks de la comunidad para otras distribuciones. **Estas se crearon cuando la compatibilidad entre distribuciones era limitada. Algunas de ellas son para la versión antigua de los *dotfiles* en AGS.**
+Los siguientes enlaces son forks de la comunidad para otras distribuciones. **Estas se crearon cuando la compatibilidad entre distribuciones era limitada. Algunas de ellas son para la versión antigua de los dotfiles en AGS.**
 
 - NixOS
   - Consulta [discusión #1093](https://github.com/end-4/dots-hyprland/discussions/1093)
@@ -200,7 +200,7 @@ source ~/.config/zshrc.d/dots-hyprland.zsh
 
 ## Iniciando Hyprland
 - Para iniciar Hyprland, puedes usar un gestor de pantalla (DM) o simplemente `tty`.
-- La wiki de Hyprland recomienda iniciar Hyprland con la sesión gestionada por uswm, pero yo no lo recomiendo. Usar esta opción no daña los *dotfiles*, pero ten en cuenta que podrías recibir mensajes no deseados de otros entornos de escritorio (por ejemplo, diálogos de autenticación duplicados).
+- La wiki de Hyprland recomienda iniciar Hyprland con la sesión gestionada por uswm, pero yo no lo recomiendo. Usar esta opción no daña los dotfiles, pero ten en cuenta que podrías recibir mensajes no deseados de otros entornos de escritorio (por ejemplo, diálogos de autenticación duplicados).
 
 Consulta la [wiki de Hyprland](https://wiki.hyprland.org/Getting-Started/Master-Tutorial/#launching-hyprland) para obtener más detalles. A continuación, encontrarás algunos consejos adicionales.
 
@@ -253,7 +253,7 @@ Hyprland 0.55 introduce la configuración en Lua en lugar de Hyprlang. Si bien a
 - Si estás listo para la versión 0.55, sigue este procedimiento:
   - Mueve la carpeta `~/.config/hypr/custom` a otra ubicación y elimínala.
   - Ejecuta `git pull` y `./setup install` como de costumbre.
-  - Usando los archivos antiguos y los nuevos archivos de configuración proporcionados por los *dotfiles* como referencia, sobrescribe tus archivos de configuración antiguos en los nuevos archivos .lua.
+  - Usando los archivos antiguos y los nuevos archivos de configuración proporcionados por los dotfiles como referencia, sobrescribe tus archivos de configuración antiguos en los nuevos archivos .lua.
 :::
 
 :::note[Resumen]
@@ -263,7 +263,7 @@ cd ~/.cache/dots-hyprland && git stash && git pull && ./setup install
 ```
 :::
 
-Por el momento, no tenemos de un verificador de actualizaciones ni un sistema de actualización automatizado. Dado que el script de instalación está diseñado para ser idempotente, para actualizar los *dotfiles*, deberás ejecutar el script de instalación nuevamente cada vez que desees actualizar, después de descargar los últimos cambios del repositorio.
+Por el momento, no tenemos de un verificador de actualizaciones ni un sistema de actualización automatizado. Dado que el script de instalación está diseñado para ser idempotente, para actualizar los dotfiles, deberás ejecutar el script de instalación nuevamente cada vez que desees actualizar, después de descargar los últimos cambios del repositorio.
 1. Navega al directorio del repositorio con `cd`. Por defecto, debería estar en `~/.cache/dots-hyprland`, a menos que hayas clonado el repositorio en otra ubicación.
 2. Ejecuta `git stash` para guardar los cambios locales. Idealmente, la instalación no debería modificar los archivos locales gestionados por Git, pero esto podría ocurrir inesperadamente, por lo que deberás guardarlos antes de descargar los últimos cambios.
 3. Ejecuta `git pull` para obtener y descargar los últimos cambios del repositorio.

--- a/src/content/docs/es/ii-qs/01.setup.mdx
+++ b/src/content/docs/es/ii-qs/01.setup.mdx
@@ -1,7 +1,7 @@
 ---
-title: Instalar/ Actualizar / Desinstalar
+title: Instalar / Actualizar / Desinstalar
 layout: /src/layouts/autonum.astro
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
@@ -13,13 +13,13 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Métodos
 
-- [Automatizado](#automated-installation): con un script
-- [Manual](#manual-installation): clona y pega manualmente
-- [Forks de la comunidad](#forks): installación especializada para ciertas distribuciones
-- [Distribuciones de terceros](#3rd-party-distros): sistemas operativos que ofrecen illogical-impulse listo para usar
+- [Automatizado](#instalación-automatizada): con un script.
+- [Manual](#instalación-manual): clona y pega manualmente.
+- [Forks de la comunidad](#forks): installación especializada para ciertas distribuciones.
+- [Distribuciones de terceros](#distribuciones-de-terceros): sistemas operativos que ofrecen illogical-impulse listo para usar.
 
 :::tip[Migración de versión AGS]
-*Omite esto si no usas la versión antigua de AGS o averígüalo por tu cuenta si no usas Arch Linux*
+*Omite esto si no usas la versión antigua de AGS o averígüalo por tu cuenta si no usas Arch Linux.*
 
 La versión Quickshell debería funcionar correctamente después de la instalación, pero puede desinstalar los paquetes antiguos antes de instalar los nuevos:
 
@@ -43,7 +43,7 @@ git clone --recursive https://github.com/end-4/dots-hyprland && cd dots-hyprland
 El script detecta automáticamente la distribución antes de continuar.
 Este es un resumen del estado de soporte de las distribuciones:
 - **Mantenido por desarrolladores:**
-  - [Arch Linux](https://archlinux.org/) y [EndeavourOS](https://endeavouros.com/) están bien mantenidas
+  - [Arch Linux](https://archlinux.org/) y [EndeavourOS](https://endeavouros.com/) están bien mantenidos.
   - [CachyOS](https://cachyos.org/) debería de funcionar bien, aunque en casos raros las diferencias en paquetes pueden causar problemas para usuarios inexpertos. Lo mismo aplica a otras distribuciones basadas en Arch.
 - **Mantenido por la comunidad:**
   - [Gentoo](https://www.gentoo.org/) (consulta [sdata/dist-gentoo/README.md](https://github.com/end-4/dots-hyprland/blob/main/sdata/dist-gentoo/README.md) para más información).
@@ -115,9 +115,9 @@ Los siguientes enlaces son forks de la comunidad para otras distribuciones. **Es
 - OpenSUSE
   - Consulta [discusión #485](https://github.com/end-4/dots-hyprland/discussions/485)
   
-## Installación manual
+## Instalación manual
 
-Para básicamente cualquier distribución
+Para básicamente cualquier distribución.
 
 :::caution
 Esta sección solo existe por demostración.
@@ -159,7 +159,7 @@ Lee el contenido de `sdata/subcmd-install/2.setups.sh`.
   - `Ctrl`+`Super`+`T` para seleccionar un fondo de pantalla.
   - `Super`+`/` para ver la lista de atajos de teclado. ¡Diviértete!
 
-## 3rd-party distros
+## Distribuciones de terceros
 
 **Incluimos estas distribuciones aquí para tu información. No las respaldamos directamente y recomendamos actuar bajo tu criterio al seleccionar tu sistema operativo.**
 
@@ -219,7 +219,7 @@ P.D. Se recomienda deshabilitar el DM si deseas iniciar Hyprland a través de tt
 
 ### Soy un novato. ¿Qué es un tty y DM?
 
-Aquí hay una breve introducción para darte un acceso rápido, aunque no exactamente cierto.
+Aquí hay una breve introducción para darte un acceso rápido, aunque **no exactamente cierto**.
 
 Puedes ver `tty` como una especie de "base" de un sistema Linux.
 Normalmente hay 7 `tty`s: `tty1` a `tty7`. Puedes presionar `Ctrl+Alt+F<n>` para cambiar a `tty<n>`, y escribir tu nombre de usuario y contraseña para iniciar sesión.
@@ -233,16 +233,16 @@ Entonces, aquí viene el DM (Display Manager, también llamado "LM", es decir, L
 - Algunos DM comúnmente usados:
   - `sddm`: A menudo usado con KDE Plasma.
   - `gdm`: A menudo usado con Gnome.
-- Está habilitado a nivel del sistema y se inicia automáticamente después de arrancar el sistema (aún no iniciar sesión).
+- Está habilitado a nivel del sistema y se inicia automáticamente después de arrancar el sistema (aún sin iniciar sesión).
   - En una distro basada en systemd, el DM generalmente está habilitado como un servicio systemd. Ejecuta lo siguiente para ver qué DM está habilitado.
     ```bash
     grep 'ExecStart=' /etc/systemd/system/display-manager.service
     ```
-    Si devuelve `No such file or directory`, entonces no hay DM habilitado, o esta no es una distro basada en systemd.
+    Si devuelve `No such file or directory`, entonces no hay DM habilitado, o esta no es una distribución basada en systemd.
 - Te proporciona una interfaz gráfica para iniciar sesión y elegir el entorno gráfico (por ejemplo, Hyprland).
   - ¿Cómo sabe el DM qué entornos gráficos están disponibles?
-   - Normalmente, busca en la ruta `/usr/share/xsessions` para los de X11, y `/usr/share/wayland-sessions` para los de Wayland.
-   - Los archivos de escritorio bajo estos directorios contienen la información de los entornos gráficos.
+    - Normalmente, busca en la ruta `/usr/share/xsessions` para los de X11, y `/usr/share/wayland-sessions` para los de Wayland.
+    - Los archivos de escritorio bajo estos directorios contienen la información de los entornos gráficos.
 
 # Actualización
 
@@ -282,6 +282,6 @@ Aunque no se recomienda en absoluto, si lo instalaste manualmente:
 :::
 
 
-# Uninstalling
+# Desinstalación
 
-Just run `./setup uninstall`, but note that it's not perfect and not actively maintained so you need to choose carefully when answering the prompts.
+Solo ejecuta `./setup uninstall`, pero ten en cuenta que no es perfecto ni recibe mantenimiento activo, por lo que debes elegir con cuidado al responder a las preguntas.

--- a/src/content/docs/es/ii-qs/01.setup.mdx
+++ b/src/content/docs/es/ii-qs/01.setup.mdx
@@ -15,7 +15,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 - [Automatizado](#instalación-automatizada): con un script.
 - [Manual](#instalación-manual): clona y pega manualmente.
-- [Forks de la comunidad](#forks): installación especializada para ciertas distribuciones.
+- [Forks de la comunidad](#forks): instalación especializada para ciertas distribuciones.
 - [Distribuciones de terceros](#distribuciones-de-terceros): sistemas operativos que ofrecen illogical-impulse listo para usar.
 
 :::tip[Migración de versión AGS]
@@ -263,7 +263,7 @@ cd ~/.cache/dots-hyprland && git stash && git pull && ./setup install
 ```
 :::
 
-Por el momento, no tenemos de un verificador de actualizaciones ni un sistema de actualización automatizado. Dado que el script de instalación está diseñado para ser idempotente, para actualizar los dotfiles, deberás ejecutar el script de instalación nuevamente cada vez que desees actualizar, después de descargar los últimos cambios del repositorio.
+Por el momento, no tenemos un verificador de actualizaciones ni un sistema de actualización automatizado. Dado que el script de instalación está diseñado para ser idempotente, para actualizar los dotfiles, deberás ejecutar el script de instalación nuevamente cada vez que desees actualizar, después de descargar los últimos cambios del repositorio.
 1. Navega al directorio del repositorio con `cd`. Por defecto, debería estar en `~/.cache/dots-hyprland`, a menos que hayas clonado el repositorio en otra ubicación.
 2. Ejecuta `git stash` para guardar los cambios locales. Idealmente, la instalación no debería modificar los archivos locales gestionados por Git, pero esto podría ocurrir inesperadamente, por lo que deberás guardarlos antes de descargar los últimos cambios.
 3. Ejecuta `git pull` para obtener y descargar los últimos cambios del repositorio.

--- a/src/content/docs/es/ii-qs/02.usage.mdx
+++ b/src/content/docs/es/ii-qs/02.usage.mdx
@@ -1,17 +1,17 @@
 ---
 title: Uso
 layout: /src/layouts/autonum.astro
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
-Esta página documenta algunos detalles no tan evidentes. NO todo está aquí, así que explora...
+Esta página documenta algunos detalles no tan evidentes. No todo está aquí, así que explora...
 
 # General
 
-Presiona `Super`+`/` para una lista de atajos de teclado
+Presiona `Super`+`/` para una lista de atajos de teclado.
 
 <details> 
-  <summary>En caso de que no funcione, aquí tienes una imagen</summary>
+  <summary>En caso de que no funcione, aquí tienes una imagen.</summary>
 
   <img width="1412" height="828" alt="image" src="https://github.com/user-attachments/assets/8f7bd216-9e03-47e3-8709-0008772a4133" />
 
@@ -19,20 +19,20 @@ Presiona `Super`+`/` para una lista de atajos de teclado
 
 ## Vista general
 
-- Ábrela con `Super` o `Super`+`Tab`
-- Arrastra una ventana a otro espacio de trabajo para enviarla allí
-- Clic con el botón central del ratón para cerrar la ventana
+- Ábrela con `Super` o `Super`+`Tab`.
+- Arrastra una ventana a otro espacio de trabajo para enviarla allí.
+- Clic con el botón central del ratón para cerrar la ventana.
 
 ## Lanzador de aplicaciones
 
 - Incluido en la vista general. Solo tienes que empezar a escribir.
 - Los resultados pueden incluir:
-  - Búsqueda de aplicaciones
-  - Resultado matemático
-  - [Prefijo: `/`] Acciones del lanzador
-  - [Prefijo: `;`] Historial del portapapeles
-  - [Prefijo: `:`] Emojis
-  - Acciones adicionales para el contenido escrito: ejecutar comando, realizar búsqueda
+  - Búsqueda de aplicaciones.
+  - Resultado matemático.
+  - [Prefijo: `/`] Acciones del lanzador.
+  - [Prefijo: `;`] Historial del portapapeles.
+  - [Prefijo: `:`] Emojis.
+  - Acciones adicionales para el contenido escrito: ejecutar comando, realizar búsqueda.
 
 - Acciones del lanzador no evidentes:
   - /superpaste NUM_OF_ENTRIES[i]: Pega NUM_OF_ENTRIES últimas entradas del portapapeles. Especifica `i` para imágenes.
@@ -40,19 +40,19 @@ Presiona `Super`+`/` para una lista de atajos de teclado
 
 ## Barra principal
 - Widget multimedia:
-  - Clic con el botón central: reproducir/pausar
-  - Clic con el botón derecho: siguiente pista
-  - Botón 4/Botón 5 del ratón: pista anterior/siguiente
-- Brillo: desplázate con la rueda en la esquina superior izquierda
-- Volumen: desplázate con la rueda en la esquina superior derecha
+  - Clic con el botón central: reproducir/pausar.
+  - Clic con el botón derecho: siguiente pista.
+  - Botón 4/Botón 5 del ratón: pista anterior/siguiente.
+- Brillo: desplázate con la rueda en la esquina superior izquierda.
+- Volumen: desplázate con la rueda en la esquina superior derecha.
 - Espacios de trabajo:
-  - Botón 4 del ratón: alternar el espacio de trabajo especial
-  - Clic con el botón derecho: abrir la vista general
+  - Botón 4 del ratón: alternar el espacio de trabajo especial.
+  - Clic con el botón derecho: abrir la vista general.
 
 # Barra lateral izquierda
 
 ## Controles generales
-- Autocompletado en las pestañas de Inteligencia y Anime
+- Autocompletado en las pestañas de Inteligencia y Anime.
   - Cuando aparezcan sugerencias sobre el área de escritura, usa las teclas de flecha arriba/abajo para seleccionar la opción deseada y luego presiona Tab para confirmar tu elección.
 - ¿Quieres llevarte el asistente contigo? Para separar la barra lateral en una ventana, pulsa `Super`+`Alt`+`A`.
 
@@ -79,9 +79,9 @@ Gestionado con la herramienta de línea de comandos `trans`. No hay mucho que a�
 
 # Herramienta de captura de pantalla
 
-- `Super`+`Shift`+`S`: Recorte de pantalla | arrastra con clic izquierdo para copiar al portapapeles, arrastra con clic derecho para anotar
-- `Super`+`Shift`+`A`: Búsqueda con Google Lens
-- `Super`+`Shift`+`X`: Reconocimiento de texto
+- `Super`+`Shift`+`S`: Recorte de pantalla | arrastra con clic izquierdo para copiar al portapapeles, arrastra con clic derecho para anotar.
+- `Super`+`Shift`+`A`: Búsqueda con Google Lens.
+- `Super`+`Shift`+`X`: Reconocimiento de texto.
 
 # Traducción de pantalla
 
@@ -94,7 +94,7 @@ Traduce el contenido de la pantalla mediante la API de Google Cloud Vision y Tra
 
 ## Configuración
 
-- Navega a [Google Cloud](https://console.cloud.google.com/) y crea o selecciona un proyecto. Puede ser el mismo proyecto que usaste para el API de Gemini si la configuraste para el chat de la barra lateral.
+- Navega a la [Consola de Google Cloud](https://console.cloud.google.com/) y crea o selecciona un proyecto. Puede ser el mismo proyecto que usaste para el API de Gemini si la configuraste para el chat de la barra lateral.
 - Habilita las siguientes APIs:
   - [Cloud Vision API](https://console.cloud.google.com/marketplace/product/google/vision.googleapis.com)
   - [Cloud Translation API](https://console.cloud.google.com/marketplace/product/google/translate.googleapis.com)

--- a/src/content/docs/es/ii-qs/02.usage.mdx
+++ b/src/content/docs/es/ii-qs/02.usage.mdx
@@ -1,0 +1,162 @@
+---
+title: Uso
+layout: /src/layouts/autonum.astro
+lastUpdated: 2026-07-07
+---
+
+Esta página documenta algunos detalles no tan evidentes. NO todo está aquí, así que explora...
+
+# General
+
+Presiona `Super`+`/` para una lista de atajos de teclado
+
+<details> 
+  <summary>En caso de que no funcione, aquí tienes una imagen</summary>
+
+  <img width="1412" height="828" alt="image" src="https://github.com/user-attachments/assets/8f7bd216-9e03-47e3-8709-0008772a4133" />
+
+</details>
+
+## Vista general
+
+- Ábrela con `Super` o `Super`+`Tab`
+- Arrastra una ventana a otro espacio de trabajo para enviarla allí
+- Clic con el botón central del ratón para cerrar la ventana
+
+## Lanzador de aplicaciones
+
+- Incluido en la vista general. Solo tienes que empezar a escribir.
+- Los resultados pueden incluir:
+  - Búsqueda de aplicaciones
+  - Resultado matemático
+  - [Prefijo: `/`] Acciones del lanzador
+  - [Prefijo: `;`] Historial del portapapeles
+  - [Prefijo: `:`] Emojis
+  - Acciones adicionales para el contenido escrito: ejecutar comando, realizar búsqueda
+
+- Acciones del lanzador no evidentes:
+  - /superpaste NUM_OF_ENTRIES[i]: Pega NUM_OF_ENTRIES últimas entradas del portapapeles. Especifica `i` para imágenes.
+  - /todo TASK: Agrega elemento a la lista de tareas.
+
+## Barra principal
+- Widget multimedia:
+  - Clic con el botón central: reproducir/pausar
+  - Clic con el botón derecho: siguiente pista
+  - Botón 4/Botón 5 del ratón: pista anterior/siguiente
+- Brillo: desplázate con la rueda en la esquina superior izquierda
+- Volumen: desplázate con la rueda en la esquina superior derecha
+- Espacios de trabajo:
+  - Botón 4 del ratón: alternar el espacio de trabajo especial
+  - Clic con el botón derecho: abrir la vista general
+
+# Barra lateral izquierda
+
+## Controles generales
+- Autocompletado en las pestañas de Inteligencia y Anime
+  - Cuando aparezcan sugerencias sobre el área de escritura, usa las teclas de flecha arriba/abajo para seleccionar la opción deseada y luego presiona Tab para confirmar tu elección.
+- ¿Quieres llevarte el asistente contigo? Para separar la barra lateral en una ventana, pulsa `Super`+`Alt`+`A`.
+
+## Chat con IA
+
+- Escribe `/model` para seleccionar un modelo. Los modelos Ollama instalados localmente se detectan automáticamente.
+- Escribe `/key` para instrucciones en cómo obtener una llave API para modelos en línea.
+- Actualmente, los modelos Gemini con herramientas pueden editar la configuración de tu shell. Por ejemplo, puedes indicarle que "oculte los íconos de las aplicaciones en mis espacios de trabajo".
+
+## Traductor
+
+Gestionado con la herramienta de línea de comandos `trans`. No hay mucho que añadir...
+
+## Anime boorus
+
+- Escribe `/mode` para ver los proveedores disponibles.
+- Escribe una o varias etiquetas para ver resultados. Aparecerán sugerencias mientras escribes.
+- Escribe un número para seleccionar la página de los resultados a consultar.
+
+# Fondo de pantalla y colores
+- Para elegir un fondo de pantalla, pulsa `Ctrl`+`Super`+`T` y selecciona una imagen. Esto también:
+  - Cambiará el color del shell, aplicaciones Qt y aplicaciones GTK.
+  - Cambiará la posición del reloj de fondo a la zona menos ocupada de la imagen (actualmente solo funciona bien con un solo monitor).
+
+# Herramienta de captura de pantalla
+
+- `Super`+`Shift`+`S`: Recorte de pantalla | arrastra con clic izquierdo para copiar al portapapeles, arrastra con clic derecho para anotar
+- `Super`+`Shift`+`A`: Búsqueda con Google Lens
+- `Super`+`Shift`+`X`: Reconocimiento de texto
+
+# Traducción de pantalla
+
+Traduce el contenido de la pantalla mediante la API de Google Cloud Vision y Translation. Esta sección te guiará a través del proceso de configuración (que puede resultar algo complejo).
+
+## Requisitos previos
+
+- Tienes una cuenta de Google.
+- Aunque no se te cobrará nada a menos que actives una cuenta completa, Google requiere una tarjeta de crédito/débito para prevenir el fraude. Una tarjeta virtual con un centavo debería funcionar, siempre y cuando sea legítima.
+
+## Configuración
+
+- Navega a [Google Cloud](https://console.cloud.google.com/) y crea o selecciona un proyecto. Puede ser el mismo proyecto que usaste para el API de Gemini si la configuraste para el chat de la barra lateral.
+- Habilita las siguientes APIs:
+  - [Cloud Vision API](https://console.cloud.google.com/marketplace/product/google/vision.googleapis.com)
+  - [Cloud Translation API](https://console.cloud.google.com/marketplace/product/google/translate.googleapis.com)
+- En el menú de navegación izquierdo, ve a la sección **Facturación**. Pulsa **Vincular una cuenta de facturación** e introduce tus datos según sean requeridos.
+- En el menú de navegación izquierdo, ve a **IAM y administración** > **Cuentas de servicio**. Pulsa **Crear cuenta de servicio** y, posteriormente:
+  - Paso 1: Introduce nombres. No importa lo que introduzcas.
+  - Paso 2: Permisos: añade los roles **Consumidor de Service Usage** y **Usuario de la API de Cloud Translation** y pulsa **Continuar**.
+  - Paso 3: Solo presiona Listo.
+- Ahora deberías ver una cuenta de servicio en la lista. Haz clic en el menú de tres puntos de la derecha y luego **Administrar claves**.
+  - Haz clic en **Agregar clave** > **Crear clave nueva**.
+  - Selecciona el tipo de clave JSON (debería ser el predeterminado) y pulsa **Crear**. Se descargará un archivo JSON.
+- Abre el archivo JSON descargado y copia su contenido.
+- Abre el traductor de pantalla con `Super`+`Shift`+`T`, luego:
+  - Haz clic en el botón con ícono de llave en la parte inferior de la pantalla.
+  - Pega el contenido JSON y pulsa Enter. La traducción comenzará.
+- Después, puedes eliminar el archivo JSON, ya que está guardado de forma segura en el llavero.
+  - Nota: Actualmente, para volver a verlo, tendrás que consultar la entrada del llavero de almacenamiento seguro de `illogical-impulse`.
+
+# Grupos de espacios de trabajo
+
+## Navegación y gestión de espacio de trabajo
+
+Si 10 espacios de trabajo no son suficientes, puede usar el siguiente grupo, hasta el límite de Hyprland. Para iniciar, simplemente desplaza de más el widget de espacio de trabajo en la barra lateral derecha (o usa atajos de teclado) para cambiar a un nuevo grupo.
+
+Los atajos de teclado y los widgets de la consola funcionan sin problemas en el grupo de espacios de trabajo seleccionado. No es necesario configurar nada adicional si no cambias la cantidad de espacios de trabajo que se muestran en el indicador de espacio de trabajo o en la vista general.
+
+- **Navegando / moviendo espacios de trabajo dentro de un grupo**: Aplican los atajos estándar de Hyprland.
+  - `Super` + `2` → espacio de trabajo **12** si estás en el espacio **11-20 (grupo 2)**.
+  - `Super` + `Alt` + `3` mueve discretamente la ventana enfocada → espacio de trabajo **23** si estás en el espacio **21-30 (grupo 3)**.
+
+- **Navegando entre grupos**:
+  - Considera agregar los siguientes atajos de Hyprland para saltar a grupos de espacios de trabajo adyacentes.
+    ```ini title="~/.config/hypr/custom/keybinds.conf"
+    hl.bind("SUPER + ALT + Z", hl.dsp.focus({ workspace = "r-10" }))
+    hl.bind("SUPER + ALT + X", hl.dsp.focus({ workspace = "r+10" }))
+    ```
+- La **Vista general** y el **Indicador de espacio de trabajo** se adaptan automáticamente. El contenido mostrado depende del grupo de espacio de trabajo actual.
+
+:::tip
+Si deseas modificar los atajos de teclado o incluir [más funcionalidades](https://wiki.hypr.land/Configuring/Dispatchers/) a la navegación de espacios de trabajo, usa el script `~/.config/hypr/hyprland/scripts/workspace_action.sh`, en vez de `hyprctl dispatch`. Esto determinará el grupo de espacio de trabajo actual utilizando el ID del espacio de trabajo activo y lo dirigirá al espacio de trabajo adecuado.
+:::
+
+## Consideraciones para múltiples monitores
+
+Considera estas estrategias para la gestión eficaz de múltiples monitores:
+- Asigna el grupo 1 (espacios de trabajo 1-10) al monitor principal y el grupo 2 (espacios de trabajo 11-20) al monitor secundario:
+  - Al iniciar el sistema, mueve manualmente el espacio de trabajo inicial del monitor secundario al segundo grupo (por ejemplo, espacio de trabajo 11) usando `Super` + `0`, y luego `Ctrl` + `Super` + `Derecha`.
+  - Esto también creará un widget de vista general independiente para cada monitor.
+- Usa la [vinculación de espacios de trabajo](https://wiki.hypr.land/Configuring/Workspace-Rules/#rules) para colocar siempre espacios de trabajo específicos en monitores específicos. Obtén los nombres de todos tus monitores usando `hyprctl monitors | grep Monitor`.
+  ```ini title="~/.config/custom/general.conf"
+  # Vincula los espacios de trabajo 1-10 (grupo 1) al monitor primario
+  for i = 1, 10 do
+    hl.workspace_rule({ workspace = tostring(i), monitor = "eDP-1", default = true })
+  end
+
+  # Vincula los espacios de trabajo 11-20 (group 2) al monitor secundario
+  for i = 11, 20 do
+    hl.workspace_rule({ workspace = tostring(i), monitor = "HDMI-A-1", default = true })
+  end
+  ```
+- Enfócate en dos espacios de trabajo a la vez en cada monitor y mueve/intercambia ventanas entre monitores/grupos (usando `Super` + `Izquierda/Derecha/Arriba/Abajo` o `Super` + `Shift` + `Izquierda/Derecha/Arriba/Abajo`) según sea necesario.
+
+:::note
+Los grupos de espacios de trabajo no son compatibles de forma nativa con Hyprland ni con ningún sistema de barra de estado o widget. Esta configuración lo consigue simplemente modificando los despachadores de Hyprland y la configuración del shell.
+:::

--- a/src/content/docs/es/ii-qs/03.config.mdx
+++ b/src/content/docs/es/ii-qs/03.config.mdx
@@ -1,0 +1,182 @@
+---
+title: Configuración
+layout: /src/layouts/autonum.astro
+lastUpdated: 2026-07-07
+---
+
+# Configuración de Hyprland
+
+Hyprland es responsable de...
+- atajos de teclado
+- variables de entorno
+- pantallas/monitores/espacios de trabajo
+- animaciones de ventana
+- ...
+
+Consulta la [Wiki de Hyprland](https://wiki.hypr.land/) para obtener instrucciones generales de configuración. A continuación, solo se documentan los detalles específicos de los dotfiles.
+
+- `~/.config/hypr/` es la carpeta de configuración de Hyprland.
+- La subcarpeta `hyprland` contiene las configuraciones predeterminadas.
+- La subcarpeta `custom` es para tus configuraciones adicionales.
+
+Puedes realizar cambios en la subcarpeta anterior, pero se sobrescribirán si decides actualizar los dotfiles.
+
+:::note
+Para sobrescribir las configuraciones predeterminadas, es posible que necesites usar algunas técnicas, como `hl.unbind()` para los atajos de teclado.
+
+Si no puedes sobrescribir algo, puedes copiar el archivo de configuración predeterminado de `~/.config/hypr/hyprland/` a `~/.config/hypr/custom/` y editar `~/.config/hypr/hyprland.conf` para comentar la línea que carga el archivo de configuración predeterminado.
+
+Si encuentras algún problema con Hyprland después de actualizarlo con `./setup install`, debes revisar `~/.config/hypr/hyprland.lua` para ver si el archivo de configuración predeterminado comentado contiene los cambios necesarios.
+:::
+
+# Configuración de Quickshell
+
+Quickshell ie responsable de elementos shell como la barra principal y barra laterales.
+
+## Configuración simple
+
+### Gráfica
+
+Pulsa `Super`+`I` o el botón de engranaje en la barra lateral derecha para abrir la configuración. Ahí están las configuraciones más comunes. Si no encuentras lo que buscas, puedes probar lo siguiente.
+
+### Edición de archivo de configuración
+
+El archivo de configuración es `~/.config/illogical-impulse/config.json`
+
+Para entender las opciones y valores definidos, consulta `~/.config/quickshell/ii/modules/common/Config.qml`
+
+:::note
+Para configuraciones que no se limitan a Quickshell, consulta la sección "Varios".
+:::
+### Formato de fecha y hora
+
+Puedes cambiar el formato de hora entre 24 y 12 horas en Configuración > General > Hora.
+
+Alternativamente, edita `time.format` en el archivo de configuración. Consulta https://doc.qt.io/qt-6/qtime.html#toString para ver el formato.
+
+## Configuración avanzada
+
+- Edita los archivos en `~/.config/quickshell/ii`
+- Consulta la [documentación de Quickshell](https://quickshell.outfoxxed.me/docs/types/)
+  - Se recomienda revisar al menos las páginas de Introducción, Posicionamiento y Lenguaje QML.
+
+# Varios
+
+## Temas de color
+
+### Vscode
+
+- Instala la extensión [Material Code](https://marketplace.visualstudio.com/items?itemName=rakib13332.material-code) y luego selecciona un fondo de pantalla.
+- Ajustes opcionales
+  - Puedes cambiar la opción "material-code.syntaxTheme", que tiene una configuración muy rara.
+  - Ejecuta "Material Code: Aplicar estilos" para añadir esquinas redondeadas. Si VSCode indica que la instalación está dañada, puedes seleccionar "No volver a mostrar".
+
+Esto funciona con la versión propietaria de Microsoft. Si usas alguna versión esquiza, no garantizamos que funcione. Bueno, solo se trata de rutas de archivo diferentes, así que no dudes en crear un PR para el fork de VSCode que uses. El script que gestiona el color se encuentra en `dots/.config/quickshell/ii/scripts/colors/code/material-code-set-color.sh`.
+
+## Cambiar la escala de la interfaz (todo)
+
+Para cambiar la escala de todos los elementos de tu pantalla, modifica el archivo `~/.config/hypr/custom/general.lua` siguiendo las instrucciones de la [wiki de Hyprland](https://wiki.hypr.land/Configuring/Basics/Monitors/).
+
+Como alternativa, para una interfaz gráfica, puedes usar `nwg-look` (debe instalarse por separado). Debería funcionar sin problemas con estos dotfiles.
+
+## Cambiar la escala de la interfaz (shell)
+
+Esto funciona ajustando la variable de entorno `QT_SCALE_FACTOR`. Existen dos métodos: el pragma Quickshell y las variables de entorno Hyprland. El primero afecta solo al shell, pero no facilita las actualizaciones. El segundo afecta a todas las aplicaciones Qt, pero sí facilita las actualizaciones.
+
+### Pragma de Quickshell
+
+Abre `~/.config/quickshell/ii/shell.qml` y modifica esta línea. Reinicia Quickshell (Ctrl+Super+R) para aplicar
+```qml
+//@ pragma Env QT_SCALE_FACTOR=1
+```
+
+### Variables de entorno de Hyprland
+
+Edita `~/.config/hypr/custom/env.lua` para incluir la siguiente línea (recuerda ajustarla según tus necesidades). Deberás reiniciar Hyprland (cerrando e iniciando sesión).
+
+```ini
+hl.env("QT_SCALE_FACTOR", "1")
+```
+
+:::tip[Consejo: primero encuentra el valor deseado]
+Quizás quieras usar el método pragma de Quickshell para encontrar el punto óptimo antes de aplicar la variable de entorno, evitando así tener que volver a iniciar sesión varias veces.
+:::
+
+## Cambiar tamaño de fuente
+
+### Aplicaciones GTK
+
+- Usa `gnome-tweaks` si quieres una interfaz gráfica con selector de fuentes.
+- De lo contrario, puedes usar `gsettings`.
+```bash
+# Sintaxis
+gsettings set org.gnome.desktop.interface font-name 'FONT_NAME FONT_SIZE'
+# Valor predeterminado para estos dotfiles
+gsettings set org.gnome.desktop.interface font-name 'Rubik 11'
+```
+
+### Aplicaciones Qt
+Puedes usar la aplicación de Configuración del sistema KDE para personalizar las fuentes.
+
+## Bloqueo de pantalla/Tiempo de espera
+
+### Tiempo de espera
+
+Referencia: [Hyprland Wiki](https://wiki.hypr.land/Hypr-Ecosystem/hypridle/)
+
+Edita `~/.config/hypr/hypridle.conf` según tus necesidades.
+
+### Usar otro programa de bloqueo de pantalla
+Referencia: [Arch Wiki](https://wiki.archlinux.org/title/Session_lock)
+
+Tomemos como ejemplo `swaylock`.
+
+Edita `~/.config/hypr/hypridle.conf` y modifica el valor de `$lock_cmd` de la siguiente manera:
+```ini
+$lock_cmd = swaylock
+```
+
+Reinicia `hypridle` después de realizar tus cambios (`pkill hypridle; hypridle & disown`).
+
+Ahora `loginctl lock-session` llamará `swaylock` para bloquear la pantalla.
+
+:::note[Cómo funciona]
+El comando `loginctl lock-session` enviará una señal al proceso `hypridle` en ejecución, y luego `hypridle` activará el comando a partir del valor de `$lock_cmd`.
+:::
+
+## Cloudflare WARP
+- Esto podría ayudarte a evitar las restricciones de tu ISP y ofrecerte una conexión a Internet más rápida.
+- También puedes usar el botón de la barra lateral derecha para alternarlo.
+- Para instalar y configurar WARP:
+  1. Instala el paquete manualmente si aún no lo has hecho.  
+  Si usas una distribución basada en Arch, puedes instalarlo desde AUR con `yay`:
+        ```bash
+        yay -S cloudflare-warp-bin
+        ```
+  2. Habilita e inicia el servicio WARP:
+        ```bash
+        sudo systemctl enable warp-svc
+        sudo systemctl start warp-svc
+        ```
+  3. Registra tu dispositivo:
+        ```bash
+        warp-cli registration new
+        ```
+        Te pedirá aceptar los Términos de servicio, escribe `y` y presiona Enter.  
+  4. Prueba la conexión:
+        ```bash
+        warp-cli connect
+        warp-cli disconnect
+        ```
+        Deberías ver `Success` como salida de ambos comandos.  
+  5. Para comprobar que el botón de la barra lateral funciona, haz clic en él y verifica el estado:
+        ```bash
+        warp-cli status
+        ```
+        Debería de mostrar `Status update :` seguido `Connected` o `Disconnected` según el estado actual de conexión.  
+        También puedes revisar el estado de la conexión visitando la página [1.1.1.1 Connection Information](https://1.1.1.1/help).  
+  6. *(Opcional)* Si deseas configurar el modo de funcionamiento de WARP (por ejemplo, crear un túnel mediante WARP y usar DNS-over-TLS para las consultas DNS), ejecuta:
+        ```bash
+        warp-cli mode warp+dot
+        ```
+        Consulta `warp-cli mode --help` para más información.

--- a/src/content/docs/es/ii-qs/03.config.mdx
+++ b/src/content/docs/es/ii-qs/03.config.mdx
@@ -1,23 +1,23 @@
 ---
 title: Configuración
 layout: /src/layouts/autonum.astro
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 # Configuración de Hyprland
 
 Hyprland es responsable de...
-- atajos de teclado
-- variables de entorno
-- pantallas/monitores/espacios de trabajo
-- animaciones de ventana
+- Atajos de teclado.
+- Variables de entorno.
+- Pantallas/monitores/espacios de trabajo.
+- Animaciones de ventana.
 - ...
 
 Consulta la [Wiki de Hyprland](https://wiki.hypr.land/) para obtener instrucciones generales de configuración. A continuación, solo se documentan los detalles específicos de los dotfiles.
 
 - `~/.config/hypr/` es la carpeta de configuración de Hyprland.
-- La subcarpeta `hyprland` contiene las configuraciones predeterminadas.
-- La subcarpeta `custom` es para tus configuraciones adicionales.
+  - La subcarpeta `hyprland` contiene las configuraciones predeterminadas.
+  - La subcarpeta `custom` es para tus configuraciones adicionales.
 
 Puedes realizar cambios en la subcarpeta anterior, pero se sobrescribirán si decides actualizar los dotfiles.
 
@@ -31,7 +31,7 @@ Si encuentras algún problema con Hyprland después de actualizarlo con `./setup
 
 # Configuración de Quickshell
 
-Quickshell ie responsable de elementos shell como la barra principal y barra laterales.
+Quickshell es responsable de elementos shell como la barra principal y barra laterales.
 
 ## Configuración simple
 
@@ -41,9 +41,9 @@ Pulsa `Super`+`I` o el botón de engranaje en la barra lateral derecha para abri
 
 ### Edición de archivo de configuración
 
-El archivo de configuración es `~/.config/illogical-impulse/config.json`
+El archivo de configuración es `~/.config/illogical-impulse/config.json`.
 
-Para entender las opciones y valores definidos, consulta `~/.config/quickshell/ii/modules/common/Config.qml`
+Para entender las opciones y valores predeterminados, consulta `~/.config/quickshell/ii/modules/common/Config.qml`.
 
 :::note
 Para configuraciones que no se limitan a Quickshell, consulta la sección "Varios".
@@ -56,22 +56,22 @@ Alternativamente, edita `time.format` en el archivo de configuración. Consulta 
 
 ## Configuración avanzada
 
-- Edita los archivos en `~/.config/quickshell/ii`
-- Consulta la [documentación de Quickshell](https://quickshell.outfoxxed.me/docs/types/)
+- Edita los archivos en `~/.config/quickshell/ii`.
+- Consulta la [documentación de Quickshell](https://quickshell.outfoxxed.me/docs/types/).
   - Se recomienda revisar al menos las páginas de Introducción, Posicionamiento y Lenguaje QML.
 
 # Varios
 
 ## Temas de color
 
-### Vscode
+### Visual Studio Code
 
 - Instala la extensión [Material Code](https://marketplace.visualstudio.com/items?itemName=rakib13332.material-code) y luego selecciona un fondo de pantalla.
 - Ajustes opcionales
   - Puedes cambiar la opción "material-code.syntaxTheme", que tiene una configuración muy rara.
-  - Ejecuta "Material Code: Aplicar estilos" para añadir esquinas redondeadas. Si VSCode indica que la instalación está dañada, puedes seleccionar "No volver a mostrar".
+  - Ejecuta "Material Code: Aplicar estilos" para añadir esquinas redondeadas. Si Visual Studio Code indica que la instalación está dañada, puedes seleccionar "No volver a mostrar".
 
-Esto funciona con la versión propietaria de Microsoft. Si usas alguna versión esquiza, no garantizamos que funcione. Bueno, solo se trata de rutas de archivo diferentes, así que no dudes en crear un PR para el fork de VSCode que uses. El script que gestiona el color se encuentra en `dots/.config/quickshell/ii/scripts/colors/code/material-code-set-color.sh`.
+Esto funciona con la versión propietaria de Microsoft. Si usas alguna versión esquiza, no garantizamos que funcione. Bueno, solo se trata de rutas de archivo diferentes, así que no dudes en crear un PR para el fork de Visual Studio Code que uses. El script que gestiona el color se encuentra en `dots/.config/quickshell/ii/scripts/colors/code/material-code-set-color.sh`.
 
 ## Cambiar la escala de la interfaz (todo)
 
@@ -173,7 +173,7 @@ El comando `loginctl lock-session` enviará una señal al proceso `hypridle` en 
         ```bash
         warp-cli status
         ```
-        Debería de mostrar `Status update :` seguido `Connected` o `Disconnected` según el estado actual de conexión.  
+        Debería de mostrar `Status update :` seguido de `Connected` o `Disconnected` según el estado actual de conexión.  
         También puedes revisar el estado de la conexión visitando la página [1.1.1.1 Connection Information](https://1.1.1.1/help).  
   6. *(Opcional)* Si deseas configurar el modo de funcionamiento de WARP (por ejemplo, crear un túnel mediante WARP y usar DNS-over-TLS para las consultas DNS), ejecuta:
         ```bash

--- a/src/content/docs/es/ii-qs/04.troubleshooting.mdx
+++ b/src/content/docs/es/ii-qs/04.troubleshooting.mdx
@@ -129,7 +129,7 @@ Luego, cuando Firefox esté reproduciendo contenido multimedia, el siguiente com
 ```bash
 dbus-send --print-reply --dest=org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.ListNames|grep mpris
 ```
-the output should include
+debería incluir la siguiente salida
 ```plain
 string "org.mpris.MediaPlayer2.plasma-browser-integration"
 ```
@@ -199,19 +199,19 @@ Consulta [esta entrada del FAQ de la Wiki de Hyprland](https://wiki.hypr.land/FA
 - Establece la variable `misc:focus_on_activate` de Hyprland a `false`.
 
 ## ¿Cómo desactivo las funciones relacionadas con anime?
-- Abre la applicación Ajustes (`Super`+`I`), ve a General y selecciona "No" para la política "Weeb".
+- Abre la aplicación Ajustes (`Super`+`I`), ve a General y selecciona "No" para la política "Weeb".
 
 ## ¿Cómo desactivo la IA o la restrinjo a modelos locales?
 
-Abre la applicación Ajustes (`Super`+`I`), ve a General y cambia la política "IA".
+Abre la aplicación Ajustes (`Super`+`I`), ve a General y cambia la política "IA".
 
 ## ¿Cómo elimino el redondeo falso de la pantalla?
 
-Hay una opción en la applicación Ajustes. Explórala.
+Hay una opción en la aplicación Ajustes. Explórala.
 
 ## Los colores de la terminal no son muy legibles
 
-En la applicación Ajustes, ve a la sección "Avanzado". Reduce el valor de Armonía de la terminal.
+En la aplicación Ajustes, ve a la sección "Avanzado". Reduce el valor de Armonía de la terminal.
 
 ## ¿Existe una configuración rápida de Proxy/VPN? Estoy en Rusia y mi proveedor de internet no quiere que vea hentai
 

--- a/src/content/docs/es/ii-qs/04.troubleshooting.mdx
+++ b/src/content/docs/es/ii-qs/04.troubleshooting.mdx
@@ -1,0 +1,228 @@
+---
+title: Solución de problemas/FAQ
+layout: /src/layouts/autonum.astro
+lastUpdated: 2026-07-08
+---
+
+:::tip
+En esta página, presiona `Ctrl`+`F` para buscar o ve la barra lateral derecha para encontrar tu problema.
+:::
+
+# Solución de problemas generales
+
+## Dependencias rotas después de actualizar los paquetes del sistema
+Tomemos como ejemplo Arch Linux: después de ejecutar `sudo pacman -Syu`, se actualizan los paquetes del sistema, sin actualizar los paquetes compilados localmente por illogical-impulse.
+
+Ejecuta lo siguiente para reinstalar las dependencias:
+```sh
+git stash && git pull  # Actualizar el repositorio git
+./setup install-deps
+```
+
+## Quickshell no se inicia (no hay barra de estado)
+
+Primero, ejecútalo en un terminal para obtener los registros.
+```bash
+pkill qs; qs -c ii
+```
+Léelo con atención. Normalmente, el mensaje de error relevante se encuentra cerca del final. Consulta uno de los siguientes casos.
+
+### Errores comunes
+
+#### El módulo "Quickshell.SOME_MODULE" no está instalado
+
+Ejemplo de salida:
+```sh
+  ERROR:   caused by @services/PolkitService.qml[6:1]: module "Quickshell.Services.Polkit" is not installed
+  WARN: QThreadStorage: entry 1 destroyed before end of thread 0x7f4e91a18830
+```
+**Solución**: Actualiza Quickshell ejecutando de nuevo el script de instalación, omitiendo todo excepto la instalación de Quickshell.
+
+#### El módulo "qs.modules.common.widgets.shapes" no está instalado
+
+Ejemplo de salida:
+```sh
+  ERROR:   caused by @modules/common/widgets/MaterialShape.qml[1:1]: module "qs.modules.common.widgets.shapes" is not installed
+```
+**Solución**: El repositorio no se clonó correctamente con submódulos. Puedes:
+- Instalaciones con script: No omitas el paso en el que se solicita actualizar los submódulos de git.
+- Instalaciones manuales: 
+  - Debes clonar el repositorio con la opción `--recurse-submodules`. Simplemente usando el botón de descarga *no* funciona.
+  - Como alternativa, desde un repositorio clonado, ejecuta `git submodule update --init --recursive`.
+
+## Entorno virtual de Python
+
+La variable de entorno `$ILLOGICAL_IMPULSE_VIRTUAL_ENV` debe estar configurada correctamente, o algunas características de la configuración de Quickshell no funcionarán. La configuración predeterminada, `~/.config/hypr/hyprland/env.lua`, cargada por `~/.config/hypr/hyprland.lua`, ya tiene esta variable.
+
+Si por alguna razón no está ahí, agrega lo siguiente a tu configuración de Hyprland y reinícialo:
+```ini
+hl.env("ILLOGICAL_IMPULSE_VIRTUAL_ENV", home_dir .. "/.local/state/quickshell/.venv")
+```
+
+Puedes ejecutar `./diagnose` para verificar el valor.
+
+Ejemplo esperado:
+```
+[===diagnose===] declare -p ILLOGICAL_IMPULSE_VIRTUAL_ENV
+declare -x ILLOGICAL_IMPULSE_VIRTUAL_ENV="/home/user/.local/state/quickshell/.venv"
+[---SUCCESS---]
+```
+Donde `user` es tu nombre de usuario.
+
+## Cosas que puedes probar al menos una vez
+- Reinicia Hyprland o tu sistema, lo cual es necesario para aplicar los cambios en las variables de entorno.
+- Ejecuta `git pull` y luego `./setup install` nuevamente para asegurarte de que todo se haya instalado correctamente. Como el script es idempotente, puedes ejecutarlo tantas veces como quieras para verificar cosas o actualizar los dotfiles.
+
+## Ayuda
+
+1. Busca en esta página, luego en [incidencias](https://github.com/end-4/dots-hyprland/issues) y [discusiones](https://github.com/end-4/dots-hyprland/discussions).
+2. Si no encuentras nada, abre una nueva discusión.
+
+Aunque [@end-4](https://github.com/end-4) es más activo en Discord (@end_4), se prefiere GitHub ya que [@clsty](https://github.com/clsty) tiene un mejor conocimiento de los scripts de instalación y los problemas relacionados con Arch Linux.
+
+# Problemas varios comunes
+## Los temas no se ven bien
+
+Cambia el fondo de pantalla pulsando `Super+Ctrl+T` y seleccionando una imagen en la ventana emergente. Si no funciona, ejecuta `~/.config/quickshell/ii/scripts/switchwall.sh` en una terminal, sigue el mismo procedimiento, consulta los registros e intenta resolverlo o envíalo a una incidencia/discusión.
+
+## Falta el ícono de alguna aplicación en el dock/vista general
+
+Técnicamente, no es posible tener íconos perfectos. Los íconos se infieren a partir de la clase de cada aplicación, que no necesariamente coincide con el nombre de su ícono.
+
+Posibles soluciones:
+### Aplicaciones GTK: Usa `gsettings` para configurar el tema de íconos
+
+Es posible que el ícono de tu aplicación no esté disponible en el paquete de íconos predeterminado. En ese caso, puedes cambiarlo por otro.
+
+Por ejemplo, puedes usar [Papirus](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme).
+No se usa por defecto debido a la preferencia de @end-4, pero tiene una gran compatibilidad con diversas aplicaciones.
+
+```sh
+gsettings set org.gnome.desktop.interface icon-theme Papirus
+```
+
+Por supuesto, primero debes instalarlo. Para Arch Linux, usa `sudo pacman -S papirus-icon-theme`.
+
+### Aplicaciones Qt: Edita la configuración de kde-material-you-colors
+
+Abre `~/.config/kde-material-you-colors/config.conf`
+Busca estas líneas y edítalas a tu preferencia.
+```ini
+# ...
+iconslight = breeze-plus
+# ...
+iconsdark = breeze-plus-dark
+```
+
+## Los controles de música no aparecen
+
+> Referencia: [end-4/dots-hyprland#168](https://github.com/end-4/dots-hyprland/issues/168) (Nota: Problema antiguo para la versión AGS)
+
+- Asegúrate de que tu reproductor sea compatible con MPRIS (aquí tienes una lista: [MPRIS - Arch Wiki](https://wiki.archlinux.org/title/MPRIS))
+- Si usas un navegador, instala la extensión Plasma Integration:
+  - [Firefox](https://addons.mozilla.org/en-US/firefox/addon/plasma-integration/)
+  - [Chromium](https://chrome.google.com/webstore/detail/plasma-integration/cimiefiiaegbelhefglklhhakcgmhkai)
+
+Asegúrate de que el paquete `plasma-browser-integration` (para Arch, busca el paquete correspondiente si no usas Arch) esté instalado.
+
+Luego, cuando Firefox esté reproduciendo contenido multimedia, el siguiente comando
+```bash
+dbus-send --print-reply --dest=org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.ListNames|grep mpris
+```
+the output should include
+```plain
+string "org.mpris.MediaPlayer2.plasma-browser-integration"
+```
+Solo funcionarán los nombres que comiencen con "plasma-browser-integration". Otros no.
+
+Si por alguna razón Firefox sigue sin mostrar dbus `org.mpris.MediaPlayer2.plasma-browser-integration`,
+considera los siguientes pasos:
+1. Crea un nuevo perfil con `firefox --ProfileManager`.
+2. Inicia Firefox con el nuevo perfil e instala de nuevo la extensión Plasma Integration.
+3. Reinicia Firefox con el nuevo perfil e inténtalo de nuevo.
+- _Nota: `playerctl -F metadata` también puede ser útil para la depuración._
+
+## Aparecen nombres extraños en los íconos en lugar de los íconos
+- Asegúrate de que la fuente Material Symbols (no Material Icons) esté instalada.
+  - En Arch, usa el paquete `ttf-material-symbols-variable-git`.
+  - Si tu distribución no tiene un paquete para ello, instálalo manualmente:
+    - Descarga los archivos .ttf del [repositorio de Material Symbols](https://github.com/google/material-design-icons/tree/master/variablefont).
+    - Colócalos en `~/.local/share/fonts`.
+    - Actualiza la caché de fuentes con `fc-cache -fv`.
+    - Reinicia la terminal con `Ctrl`+`Super`+`R`.
+
+## `loginctl lock-session` no hace nada.
+> Referencia: [end-4/dots-hyprland#278](https://github.com/end-4/dots-hyprland/issues/278).
+
+Según [esta publicación de los foros de Arch Linux](https://bbs.archlinux.org/viewtopic.php?pid=1311990#p1311990):
+> Para que esto funcione, es necesario que algo escuche las señales dbus de systemd-logind.
+
+Hypridle puede ser ese "algo", lo que significa que debes asegurarte de que esté en ejecución,
+y luego `loginctl lock-session` enviará una señal a hypridle.
+Como resultado, hypridle bloqueará la pantalla ejecutando `$lock_cmd` definido en su configuración `~/.config/hypr/hypridle.conf`.
+
+Consulta la [Wiki de Hyprland](https://wiki.hypr.land/Hypr-Ecosystem/hypridle/#configuration) para obtener más información. 
+
+## Parpadeo del brillo de la pantalla
+
+Consulta [esta entrada del FAQ de la Wiki de Hyprland](https://wiki.hypr.land/FAQ/#my-monitor-has-flickering-brightness-when-i-turn-on-vrr)
+
+## El botón de Wi-Fi de la barra lateral no funciona
+- Asegúrate de tener instalado `NetworkManager`. Para distribuciones basadas en Arch, ejecuta:
+  ```bash
+  sudo pacman -Q NetworkManager
+  sudo pacman -S NetworkManager  # si no está instalado
+  ```
+- Asegúrate de que `NetworkManager` esté ejecutándose.
+  ```bash
+  sudo systemctl status NetworkManager
+  # si no está ejecutándose, habilítalo e inícialo
+  sudo systemctl enable NetworkManager
+  sudo systemctl start NetworkManager
+  ```
+  Reinicia Quickshell para aplicar los cambios.
+- Si terminaste usando otro administrador de red (como `iwd`) para configurar el Wi-Fi (porque el interruptor de la barra lateral no funciona), puedes configurar `NetworkManager` para que use `iwd` como backend y así evitar confusiones (no puedes tener dos servicios controlando el Wi-Fi al mismo tiempo).
+  - Crea el archivo de configuración del backend para `NetworkManager`:
+    ```bash
+    sudo nano /etc/NetworkManager/conf.d/wifi_backend.conf
+    ```
+  - Agrega lo siguiente:
+    ```ini
+    [device]
+    wifi.backend=iwd
+    ```
+  - Guarda el archivo y reinicia Quickshell para aplicar los cambios.
+
+# Preguntas relacionadas a la configuración
+
+## ¿Cómo evito que Telegram u otras aplicaciones de mensajería roben el foco en los mensajes nuevos?
+- Establece la variable `misc:focus_on_activate` de Hyprland a `false`.
+
+## ¿Cómo desactivo las funciones relacionadas con anime?
+- Abre la applicación Ajustes (`Super`+`I`), ve a General y selecciona "No" para la política "Weeb".
+
+## ¿Cómo desactivo la IA o la restrinjo a modelos locales?
+
+Abre la applicación Ajustes (`Super`+`I`), ve a General y cambia la política "IA".
+
+## ¿Cómo elimino el redondeo falso de la pantalla?
+
+Hay una opción en la applicación Ajustes. Explórala.
+
+## Los colores de la terminal no son muy legibles
+
+En la applicación Ajustes, ve a la sección "Avanzado". Reduce el valor de Armonía de la terminal.
+
+## ¿Existe una configuración rápida de Proxy/VPN? Estoy en Rusia y mi proveedor de internet no quiere que vea hentai
+
+Para eludir las restricciones de contenido, shell ofrece una opción rápida para activar Cloudflare Warp si lo tienes instalado. Puedes consultar la sección correspondiente en la página de Configuración.
+
+## ¿Cómo habilitar la transparencia?
+
+Consulta [#1991](https://github.com/end-4/dots-hyprland/discussions/1991)
+
+# Hacking
+
+## Quiero [hacer esta cosa muy específica]
+
+Prueba https://deepwiki.com/end-4/dots-hyprland

--- a/src/content/docs/es/ii-qs/05.faq.mdx
+++ b/src/content/docs/es/ii-qs/05.faq.mdx
@@ -1,12 +1,12 @@
 ---
 title: FAQ general
-lastUpdated: 2026-07-07
+lastUpdated: 2026-07-08
 ---
 
 _Para problemas de uso, consulta la página de Solución de problemas/FAQ. Esta página es para temas generales._
 
 ---
-- **P: Brooo, esto es demasiado genial, ¿cómo aprendo a hacer estas cositas???? ¿Paso a paso??? ¿Ayuda?? Porfa no me dejes de hablar, bro**
+- **P: Brooo, esto es demasiado genial, ¿cómo aprendo a hacer estas cositas???? ¿Paso a paso??? ¿Ayuda?? Porfa no me dejes de hablar, bro.**
 - R: Para empezar con Quickshell, consulta su [Guía de uso](https://quickshell.org/docs/v0.3.0/guide/). No hay atajos y no es posible recordar todo lo que he hecho para guiarte.
 ---
 - **P: ¿Es difícil hacer algo como esto? ¿Cuánto tiempo te llevó?**

--- a/src/content/docs/es/ii-qs/05.faq.mdx
+++ b/src/content/docs/es/ii-qs/05.faq.mdx
@@ -1,0 +1,32 @@
+---
+title: FAQ general
+lastUpdated: 2026-07-07
+---
+
+_Para problemas de uso, consulta la página de Solución de problemas/FAQ. Esta página es para temas generales._
+
+---
+- **P: Brooo, esto es demasiado genial, ¿cómo aprendo a hacer estas cositas???? ¿Paso a paso??? ¿Ayuda?? Porfa no me dejes de hablar, bro**
+- R: Para empezar con Quickshell, consulta su [Guía de uso](https://quickshell.org/docs/v0.3.0/guide/). No hay atajos y no es posible recordar todo lo que he hecho para guiarte.
+---
+- **P: ¿Es difícil hacer algo como esto? ¿Cuánto tiempo te llevó?**
+- R (breve): Sí. La parte "básica" me llevó unos dos meses.
+- R (completa): Yo pude hacerlo, así que diría que es fácil. Como preguntas esto, no tienes ni idea, así que es difícil para ti. Requiere aprendizaje y no puedes confiar en la intuición para avanzar sin esfuerzo.
+---
+- **P: ¿Por qué el cambio de AGS a Quickshell?**
+- R: Consulta [dots-hyprland#1276 (comentario)](https://github.com/end-4/dots-hyprland/pull/1276#issuecomment-2860016485)
+---
+- **P: ¿Por qué el dock está desactivado por defecto?**
+- R: Interfiere con el redimensionado en el borde inferior, y la vista general es superior de todos modos.
+---
+- **P: ¿Por qué la wiki usa `ii.clsty.link` como dominio?**
+- R: Consulta [dots-hyprland-wiki#28](https://github.com/end-4/dots-hyprland-wiki/issues/28).
+---
+- **P: ¿Por qué no subir los PKGBUILD a AUR?**
+- R: En resumen: porque están **diseñados** para ser PKGBUILD **locales** incluidos dentro del repositorio Git.
+---
+- **P: ¿Por qué los PKGBUILD están diseñados para ser locales?**
+- R: Consulta [dots-hyprland#2240 (comentario)](https://github.com/end-4/dots-hyprland/issues/2240#issuecomment-3419239068).
+---
+
+

--- a/src/content/docs/es/index.mdx
+++ b/src/content/docs/es/index.mdx
@@ -1,47 +1,51 @@
 ---
-title: dots-hyprland wiki
-description: La documentación para end-4/dots-hyprland
+title: Inicio
+description: La documentación para illogical-impulse
 template: splash
 hero:
   title: |
-    <p style="font-size: 28px;">Esto es</p>
-    <p style="font-size: 55px;">illogical-impulse</p>
+    <p style="font-size: 60px; font-weight: 300">illogical-impulse</p>
   tagline: |
-    <p style="font-size: 18px;">Dotfiles de Hyprland modernos, ricos en funciones y accesibles</p>
+    <p style="font-size: 22px;">Dotfiles usables. Probablemente.</p>
   image:
     html: "<img alt='Una captura de pantalla.' src='https://repository-images.githubusercontent.com/583820372/55988d08-a8db-421a-8761-f6e98ea89ce3' width='600' />"
   actions:
     - text: Presentación
       link: ./general/showcase
-      icon: right-arrow
+      icon: star
       variant: primary
     - text: Inicio Rápido
-      link: ./ii-ags/01setup
-      icon: right-arrow
+      link: ./ii-qs/01setup#automated-installation
+      icon: rocket
       variant: primary
     - text: Repo (end-4/dots-hyprland)
       link: https://github.com/end-4/dots-hyprland
+      variant: minimal
       icon: external
 lastUpdated: false
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-## Obtén un entorno poderoso y visualmente agradable
-
 <CardGrid stagger>
-  <Card title="Widget de resumen" icon="laptop">
-    Gestiona aplicaciones abiertas sin esfuerzo.
-  </Card>
-  <Card title="Asistente de IA" icon="open-book">
-    ChatGPT y Google Gemini en una barra lateral. [Se requiere clave API]
-  </Card>
-  <Card title="Esquema de colores autogenerado" icon="pen">
-    Tu escritorio, tu fondo de pantalla. Elige uno y hará el resto.
-  </Card>
-  <Card title="Accesible" icon="rocket">
-    Las animaciones te ayudan a entender lo que está pasando.
-  </Card>
+  <Card title="[‎ ‎ [‎ Vista general de ventanas ‎] ‎ ‎]">
+    Gestiona tus escritorios sin esfuerzo con arrastrar-y-soltar.
+	</Card>
+  <Card title="+//+ Calidad de vida +//+">
+    Circula para buscar. Traducción de pantalla. Anti-flashbang. 
+	</Card>
+  <Card title=">>× IA ×<<">
+    Gemini y Ollama. Sin aplicación web. A una tecla de distancia.
+	</Card>
+  <Card title="•• Material 3 Expressive ••">
+    Aspecto corporativo atractivo, igual que tu teléfono.
+	</Card>
+  <Card title="~>< Habla tu idioma ><~">
+    Traducciones humanas y generadas por IA.
+	</Card>
+  <Card title="$>_ Fácil instalación _<$">
+    Instalación idempotente en múltiples distribuciones.
+	</Card>
 </CardGrid>
 
 > [Este wiki](https://github.com/end-4/dots-hyprland-wiki) está abierto para [contribución](https://ii.clsty.link/en/dev/doc-site-contrib).

--- a/src/content/docs/es/index.mdx
+++ b/src/content/docs/es/index.mdx
@@ -18,7 +18,7 @@ hero:
       link: ./ii-qs/01setup#automated-installation
       icon: rocket
       variant: primary
-    - text: Repo (end-4/dots-hyprland)
+    - text: Repositorio GitHub (end-4/dots-hyprland)
       link: https://github.com/end-4/dots-hyprland
       variant: minimal
       icon: external

--- a/src/content/docs/es/index.mdx
+++ b/src/content/docs/es/index.mdx
@@ -8,7 +8,7 @@ hero:
   tagline: |
     <p style="font-size: 22px;">Dotfiles usables. Probablemente.</p>
   image:
-    html: "<img alt='Una captura de pantalla.' src='https://repository-images.githubusercontent.com/583820372/55988d08-a8db-421a-8761-f6e98ea89ce3' width='600' />"
+    html: "<img alt='Una captura de pantalla.' src='/screenshots/ii-qs.1.jpg' width='600' />"
   actions:
     - text: Presentación
       link: ./general/showcase
@@ -29,7 +29,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
   <Card title="[‎ ‎ [‎ Vista general de ventanas ‎] ‎ ‎]">
-    Gestiona tus escritorios sin esfuerzo con arrastrar-y-soltar.
+    Gestiona tus espacios de trabajo con arrastrar-y-soltar.
 	</Card>
   <Card title="+//+ Calidad de vida +//+">
     Circula para buscar. Traducción de pantalla. Anti-flashbang. 
@@ -48,4 +48,4 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 	</Card>
 </CardGrid>
 
-> [Este wiki](https://github.com/end-4/dots-hyprland-wiki) está abierto para [contribución](https://ii.clsty.link/en/dev/doc-site-contrib).
+> [Esta wiki](https://github.com/end-4/dots-hyprland-wiki) está abierta para [contribución](https://ii.clsty.link/en/dev/doc-site-contrib).

--- a/src/content/i18n/es.json
+++ b/src/content/i18n/es.json
@@ -12,7 +12,7 @@
     "menuButton.accessibleLabel": "Menú",
     "sidebarNav.accessibleLabel": "Principal",
     "tableOfContents.onThisPage": "En esta página",
-    "tableOfContents.overview": "Resumen",
+    "tableOfContents.overview": "Vista general",
     "i18n.untranslatedContent": "Este contenido no está disponible en español",
     "page.editLink": "Editar página",
     "page.lastUpdated": "Última actualización:",


### PR DESCRIPTION
## Summary
This PR updates existing Spanish translations across the wiki and adds new pages for previously untranslated content.

## Changes made
- Updated the Homepage, Credits, and Showcase pages with the latest page content.
- Updated the existing AGS implementation pages with the maintenance notice.
- Added Spanish pages for the Quickshell implementation.
- Enabled localization for the "New" and "Help wanted" badges in the left sidebar menu, currently supporting English and Spanish while keeping the structure ready for additional languages in the future.